### PR TITLE
Adding fuzzers for some global clock tiles and CIBs

### DIFF
--- a/fuzzers/020-tap_drive/fuzzer.py
+++ b/fuzzers/020-tap_drive/fuzzer.py
@@ -1,0 +1,29 @@
+from fuzzconfig import FuzzConfig
+import interconnect
+import pytrellis
+
+jobs = [
+    {
+        "cfg": FuzzConfig(job="TAP_DRIVE", family="ECP5", device="LFE5U-25F", ncl="tap.ncl",
+                          tiles=["TAP_R6C22:TAP_DRIVE"]),
+        "left_net": "R6C17_HPBX{:02d}00",
+        "right_net": "R6C26_HPBX{:02d}00"
+    }
+]
+
+
+def main():
+    pytrellis.load_database("../../database")
+    for job in jobs:
+        cfg = job["cfg"]
+        cfg.setup()
+        netnames = []
+        netnames += [job["left_net"].format(x) for x in range(16)]
+        netnames += [job["right_net"].format(x) for x in range(16)]
+
+        interconnect.fuzz_interconnect_with_netnames(config=cfg, netnames=netnames,
+                                                     netname_filter_union=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzzers/020-tap_drive/fuzzer.py
+++ b/fuzzers/020-tap_drive/fuzzer.py
@@ -8,7 +8,13 @@ jobs = [
                           tiles=["TAP_R6C22:TAP_DRIVE"]),
         "left_net": "R6C17_HPBX{:02d}00",
         "right_net": "R6C26_HPBX{:02d}00"
-    }
+    },
+    {
+        "cfg": FuzzConfig(job="TAP_DRIVE_CIB", family="ECP5", device="LFE5U-25F", ncl="tap.ncl",
+                          tiles=["TAP_R13C22:TAP_DRIVE_CIB"]),
+        "left_net": "R13C17_HPBX{:02d}00",
+        "right_net": "R13C26_HPBX{:02d}00"
+    },
 ]
 
 

--- a/fuzzers/020-tap_drive/tap.ncl
+++ b/fuzzers/020-tap_drive/tap.ncl
@@ -1,0 +1,35 @@
+::FROM-WRITER;
+design top
+{
+   device
+   {
+      architecture sa5p00;
+      device LFE5U-25F;
+      package CABGA381;
+      performance "8";
+   }
+
+   comp SLICE_0
+      [,,,,A0,B0,D0,C0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]
+   {
+      logical
+      {
+         cellmodel-name SLICE;
+         program "MODE:LOGIC "
+                 "K0::H0=0 "
+                 "F0:F ";
+         primitive K0 i3_4_lut;
+      }
+      site R6C23A;
+   }
+
+    signal clk_c
+   {
+      signal-pins
+         // drivers
+         (SLICE_0, F0),
+         // loads
+         (SLICE_0, CLK);
+      ${route}
+   }
+}

--- a/fuzzers/021-spine/fuzzer.py
+++ b/fuzzers/021-spine/fuzzer.py
@@ -1,0 +1,61 @@
+from fuzzconfig import FuzzConfig
+import interconnect
+import pytrellis
+
+jobs = [
+    {
+        "cfg": FuzzConfig(job="EBR_SPINE_UL1", family="ECP5", device="LFE5U-45F", ncl="spine_45k.ncl",
+                          tiles=["MIB_R10C12:EBR_SPINE_UL1"]),
+        "sink_net": "R18C12_VPTX{:02d}00"
+    },
+    {
+        "cfg": FuzzConfig(job="EBR_SPINE_UL0", family="ECP5", device="LFE5U-45F", ncl="spine_45k.ncl",
+                          tiles=["MIB_R10C30:EBR_SPINE_UL0"]),
+        "sink_net": "R18C30_VPTX{:02d}00"
+    },
+    {
+        "cfg": FuzzConfig(job="EBR_SPINE_UR0", family="ECP5", device="LFE5U-45F", ncl="spine_45k.ncl",
+                          tiles=["MIB_R10C50:EBR_SPINE_UR0"]),
+        "sink_net": "R18C50_VPTX{:02d}00"
+    },
+    {
+        "cfg": FuzzConfig(job="EBR_SPINE_UR1", family="ECP5", device="LFE5U-45F", ncl="spine_45k.ncl",
+                          tiles=["MIB_R10C77:EBR_SPINE_UR1"]),
+        "sink_net": "R18C77_VPTX{:02d}00"
+    },
+    {
+        "cfg": FuzzConfig(job="EBR_SPINE_LL1", family="ECP5", device="LFE5U-45F", ncl="spine_45k.ncl",
+                          tiles=["MIB_R58C12:EBR_SPINE_LL1"]),
+        "sink_net": "R53C12_VPTX{:02d}00"
+    },
+    {
+        "cfg": FuzzConfig(job="EBR_SPINE_LL0", family="ECP5", device="LFE5U-45F", ncl="spine_45k.ncl",
+                          tiles=["MIB_R58C30:EBR_SPINE_LL0"]),
+        "sink_net": "R53C30_VPTX{:02d}00"
+    },
+    {
+        "cfg": FuzzConfig(job="EBR_SPINE_LR0", family="ECP5", device="LFE5U-45F", ncl="spine_45k.ncl",
+                          tiles=["MIB_R58C50:EBR_SPINE_LR0"]),
+        "sink_net": "R53C50_VPTX{:02d}00"
+    },
+    {
+        "cfg": FuzzConfig(job="EBR_SPINE_LR1", family="ECP5", device="LFE5U-45F", ncl="spine_45k.ncl",
+                          tiles=["MIB_R58C77:EBR_SPINE_LR1"]),
+        "sink_net": "R53C77_VPTX{:02d}00"
+    },
+]
+
+
+def main():
+    pytrellis.load_database("../../database")
+    for job in jobs:
+        cfg = job["cfg"]
+        cfg.setup()
+        netnames = [job["sink_net"].format(x) for x in range(16)]
+
+        interconnect.fuzz_interconnect_with_netnames(config=cfg, netnames=netnames,
+                                                     netname_filter_union=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzzers/021-spine/spine_45k.ncl
+++ b/fuzzers/021-spine/spine_45k.ncl
@@ -1,0 +1,35 @@
+::FROM-WRITER;
+design top
+{
+   device
+   {
+      architecture sa5p00;
+      device LFE5U-45F;
+      package CABGA381;
+      performance "8";
+   }
+
+   comp SLICE_0
+      [,,,,A0,B0,D0,C0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]
+   {
+      logical
+      {
+         cellmodel-name SLICE;
+         program "MODE:LOGIC "
+                 "K0::H0=0 "
+                 "F0:F ";
+         primitive K0 i3_4_lut;
+      }
+      site R6C23A;
+   }
+
+    signal clk_c
+   {
+      signal-pins
+         // drivers
+         (SLICE_0, F0),
+         // loads
+         (SLICE_0, CLK);
+      ${route}
+   }
+}

--- a/fuzzers/030-cib_routing/cibroute.ncl
+++ b/fuzzers/030-cib_routing/cibroute.ncl
@@ -1,0 +1,35 @@
+::FROM-WRITER;
+design top
+{
+   device
+   {
+      architecture sa5p00;
+      device LFE5U-25F;
+      package CABGA381;
+      performance "8";
+   }
+
+   comp SLICE_0
+      [,,,,A0,B0,D0,C0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]
+   {
+      logical
+      {
+         cellmodel-name SLICE;
+         program "MODE:LOGIC "
+                 "K0::H0=0 "
+                 "F0:F ";
+         primitive K0 i3_4_lut;
+      }
+      site R2C2A;
+   }
+
+    signal q_c
+   {
+      signal-pins
+         // drivers
+         (SLICE_0, F0),
+         // loads
+         (SLICE_0, A0);
+      ${route}
+   }
+}

--- a/fuzzers/030-cib_routing/fuzzer.py
+++ b/fuzzers/030-cib_routing/fuzzer.py
@@ -1,0 +1,34 @@
+from fuzzconfig import FuzzConfig
+import interconnect
+import nets
+import pytrellis
+import re
+
+cfg = FuzzConfig(job="CIBROUTE", family="ECP5", device="LFE5U-25F", ncl="cibroute.ncl", tiles=["CIB_R1C16:CIB"])
+
+
+def main():
+    pytrellis.load_database("../../database")
+    cfg.setup()
+
+    span1_re = re.compile(r'R\d+C\d+_[VH]01[NESWTLBR]\d{4}')
+
+    def nn_filter(net, netnames):
+        """ Match nets that are: in the tile according to Tcl, global nets, or span-1 nets that are accidentally
+        left out by Tcl"""
+        return ((net in netnames or span1_re.match(net)) and nets.is_cib(net)) or nets.is_global(net)
+
+    def fc_filter(arc, netnames):
+        """ Ignore connections between two general routing nets. These are edge buffers which vary based on location
+        and must be excluded from the CIB database.
+        """
+        return not (nets.general_routing_re.match(arc[0]) and nets.general_routing_re.match(arc[1]))
+    interconnect.fuzz_interconnect(config=cfg, location=(1, 16),
+                                   netname_predicate=nn_filter,
+                                   fc_predicate=fc_filter,
+                                   netname_filter_union=True,
+                                   enable_span1_fix=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/libtrellis/CMakeLists.txt
+++ b/libtrellis/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.5)
 project(libtrellis)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/libtrellis/examples/config_all.py
+++ b/libtrellis/examples/config_all.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-This simple example uses PyTrellis to dump config of all logic tiles as text
+This simple example uses PyTrellis to dump config of all tiles as text
 """
 import pytrellis
 import sys
@@ -8,7 +8,7 @@ import sys
 pytrellis.load_database("../../database")
 bs = pytrellis.Bitstream.read_bit(sys.argv[1])
 chip = bs.deserialise_chip()
-for tile in chip.get_tiles_by_type("PLC2"):
+for tile in chip.get_all_tiles():
     cfg = tile.dump_config()
     if len(cfg.strip()) > 0:
         print(".tile {}".format(tile.info.name))

--- a/libtrellis/include/Chip.hpp
+++ b/libtrellis/include/Chip.hpp
@@ -53,6 +53,8 @@ public:
 
     vector<shared_ptr<Tile>> get_tiles_by_type(string type);
 
+    vector<shared_ptr<Tile>> get_all_tiles();
+
     // Map tile name to a tile reference
     map<string, shared_ptr<Tile>> tiles;
 

--- a/libtrellis/src/Chip.cpp
+++ b/libtrellis/src/Chip.cpp
@@ -41,6 +41,14 @@ vector<shared_ptr<Tile>> Chip::get_tiles_by_type(string type) {
     return result;
 }
 
+vector<shared_ptr<Tile>> Chip::get_all_tiles() {
+    vector<shared_ptr<Tile>> result;
+    for (const auto &tile : tiles) {
+         result.push_back(tile.second);
+    }
+    return result;
+}
+
 int Chip::get_max_row() {
     return max_element(tiles.begin(), tiles.end(),
                [](const decltype(tiles)::value_type &a, const decltype(tiles)::value_type &b) {

--- a/libtrellis/src/PyTrellis.cpp
+++ b/libtrellis/src/PyTrellis.cpp
@@ -89,6 +89,7 @@ BOOST_PYTHON_MODULE (pytrellis) {
             .def("get_tile_by_name", &Chip::get_tile_by_name)
             .def("get_tiles_by_position", &Chip::get_tiles_by_position)
             .def("get_tiles_by_type", &Chip::get_tiles_by_type)
+            .def("get_all_tiles", &Chip::get_all_tiles)
             .def("get_max_row", &Chip::get_max_row)
             .def("get_max_col", &Chip::get_max_col)
             .def_readonly("info", &Chip::info)

--- a/tools/html_all.py
+++ b/tools/html_all.py
@@ -13,6 +13,7 @@ import argparse
 import database
 import devices
 import html_tilegrid
+import html_bits
 
 trellis_docs_index = """
 <html>
@@ -50,6 +51,16 @@ def generate_device_docs(family, device, folder):
     html_tilegrid.main(["html_tilegrid", family, device, path.join(folder, "index.html")])
 
 
+def generate_tile_docs(family, device, tile, folder):
+    html_bits.main(["html_bits", family, device, tile, path.join(folder, "{}.html".format(tile))])
+
+
+# TODO find a better way of specifying tiles, or just go for all of them
+tiles = {
+    ("ECP5", "LFE5U-25F"): ["PLC2", "TAP_DRIVE", "TAP_DRIVE_CIB", "CIB"]
+}
+
+
 def main(argv):
     args = parser.parse_args(argv[1:])
     if not path.exists(args.fld):
@@ -61,6 +72,9 @@ def main(argv):
         fdir = path.join(args.fld, fam)
         if not path.exists(fdir):
             os.mkdir(fdir)
+        thdir = path.join(fdir, "tilehtml")
+        if not path.exists(thdir):
+            os.mkdir(thdir)
         docs_toc += "<h3>{} Family</h3>".format(fam)
         docs_toc += "<ul>"
         for dev in fam_data["devices"]:
@@ -68,11 +82,16 @@ def main(argv):
             if not path.exists(ddir):
                 os.mkdir(ddir)
             generate_device_docs(fam, dev, ddir)
+            if (fam, dev) in tiles:
+                for tile in tiles[fam, dev]:
+                    generate_tile_docs(fam, dev, tile, thdir)
             docs_toc += '<li><a href="{}">{} Documentation</a></li>'.format(
                 '{}/{}/index.html'.format(fam, dev),
                 dev
             )
+
         docs_toc += "</ul>"
+
     index_html = Template(trellis_docs_index).substitute(
         datetime=build_dt,
         commit=commit_hash,

--- a/tools/html_all.py
+++ b/tools/html_all.py
@@ -57,7 +57,9 @@ def generate_tile_docs(family, device, tile, folder):
 
 # TODO find a better way of specifying tiles, or just go for all of them
 tiles = {
-    ("ECP5", "LFE5U-25F"): ["PLC2", "TAP_DRIVE", "TAP_DRIVE_CIB", "CIB"]
+    ("ECP5", "LFE5U-25F"): ["PLC2", "TAP_DRIVE", "TAP_DRIVE_CIB", "CIB"],
+    ("ECP5", "LFE5U-45F"): ["EBR_SPINE_UL1", "EBR_SPINE_UL0", "EBR_SPINE_UR0", "EBR_SPINE_UR1", "EBR_SPINE_LL1",
+                            "EBR_SPINE_LL0", "EBR_SPINE_LR0", "EBR_SPINE_LR1"]
 }
 
 

--- a/tools/html_bits.py
+++ b/tools/html_bits.py
@@ -165,6 +165,8 @@ def get_bit_info(frame, bit):
         group = bitmap[(frame, bit)]
         if group.startswith("mux"):
             label = group.split("_")[-1][0]
+            if label == "J":
+                label = group.split("_")[-1][1]
             colour = "#FF8888"
         elif group.startswith("enum") or group.startswith("word"):
             label = re.split("[_.]", group)[-1][0]

--- a/util/common/isptcl.py
+++ b/util/common/isptcl.py
@@ -120,6 +120,9 @@ def get_arcs_on_wires(desfiles, wires, drivers_only=False):
                 elif splitline[1].strip() == "<--":
                     if not drivers_only:
                         arcs.append((splitline[2].strip(), splitline[0].strip()))
+                elif splitline[1].strip() == "---":
+                    # Edge wires, currently ignored
+                    pass
                 else:
                     print (splitline)
                     assert False, "invalid output from Tcl command `dev_list_arcs`"

--- a/util/common/nets.py
+++ b/util/common/nets.py
@@ -41,7 +41,9 @@ general_routing_re = re.compile('R\d+C\d+_[VH]\d{2}[NESWTLBR]\d{4}')
 # CIB signals
 cib_signal_re = re.compile('R\d+C\d+_J?[ABCDFMQ]\d')
 # CIB clock/control signals
-cib_control_re = re.compile('R\d+C\d+_J?(CLK|LSR|CEN)\d')
+cib_control_re = re.compile('R\d+C\d+_J?(CLK|LSR|CEN|CE)\d')
+# CIB bounce signals
+cib_bounce_re = re.compile('R\d+C\d+_[NESW]BOUNCE')
 
 
 def is_cib(wire):
@@ -49,7 +51,8 @@ def is_cib(wire):
        a special function - EBR, DSP, etc)"""
     return bool(general_routing_re.match(wire) or
                 cib_signal_re.match(wire) or
-                cib_control_re.match(wire))
+                cib_control_re.match(wire) or
+                cib_bounce_re.match(wire))
 
 
 h_wire_regex = re.compile(r'H(\d{2})([EW])(\d{2})(\d{2})')
@@ -122,7 +125,7 @@ def handle_edge_name(chip_size, tile_pos, wire_pos, netname):
                 # V02S0002 --> y-1, V02S0001
                 # V02N0000 --> y-1, V02N0001
                 if vm.group(2) == "S" and wire_pos[0] == 1 and vm.group(4) == "02":
-                    return "V02S{}01".format(hm.group(3)), (wire_pos[0] - 1, wire_pos[1])
+                    return "V02S{}01".format(vm.group(3)), (wire_pos[0] - 1, wire_pos[1])
                 elif vm.group(2) == "N" and wire_pos[0] == 1 and vm.group(4) == "00":
                     return "V02N{}01".format(vm.group(3)), (wire_pos[0] - 1, wire_pos[1])
             elif tile_pos[0] == (chip_size[0] - 1):

--- a/util/common/nets.py
+++ b/util/common/nets.py
@@ -116,10 +116,12 @@ def handle_edge_name(chip_size, tile_pos, wire_pos, netname):
             assert False
     if vm:
         if vm.group(1) == "01":
-            if tile_pos[0] == chip_size[0] - 1:
+            if tile_pos[0] == 1:
                 # V01N000 --> y-1, V01N0001
-                assert vm.group(4) == "00"
-                return "V01{}{}01".format(vm.group(2), vm.group(3)), (wire_pos[0] - 1, wire_pos[1])
+                if wire_pos[0] == 1 and vm.group(2) == "N" and vm.group(4) == "00":
+                    return "V01{}{}01".format(vm.group(2), vm.group(3)), (wire_pos[0] - 1, wire_pos[1])
+                if wire_pos[0] == 1 and vm.group(2) == "S" and vm.group(4) == "01":
+                    return "V01{}{}00".format(vm.group(2), vm.group(3)), (wire_pos[0] - 1, wire_pos[1])
         elif vm.group(1) == "02":
             if tile_pos[0] == 1:
                 # V02S0002 --> y-1, V02S0001

--- a/util/common/nets.py
+++ b/util/common/nets.py
@@ -22,6 +22,17 @@ cdivx_clk_re = re.compile(r'R\d+C\d+_J?[UL]CDIVX\d+')
 # SED clock output
 sed_clk_re = re.compile(r'R\d+C\d+_J?SEDCLKOUT')
 
+# DCC signals
+dcc_clk_re = re.compile(r'R\d+C\d+_J?(CLK[IO]|CE)_[BLTR]?DCC(\d+|[BT][LR])')
+# DCC inputs
+dcc_clki_re = re.compile(r'R\d+C\d+_[BLTR]?DCC(\d+|[BT][LR])CLKI')
+# DCS signals
+dcs_sig_re = re.compile(r'R\d+C\d+_J?(CLK\d|SEL\d|DCSOUT|MODESEL)_DCS\d')
+# DCS clocks
+dcs_clk_re = re.compile(r'R\d+C\d+_DCS\d(CLK\d)?')
+# Misc. center clocks
+center_clk_re = re.compile(r'R\d+C\d+_J?(LE|BRGE|RE)CLK\d')
+
 
 def is_global(wire):
     """Return true if a wire is part of the global clock network"""
@@ -33,7 +44,11 @@ def is_global(wire):
                 cib_clk_re.match(wire) or
                 osc_clk_re.match(wire) or
                 cdivx_clk_re.match(wire) or
-                sed_clk_re.match(wire))
+                sed_clk_re.match(wire) or
+                dcc_clk_re.match(wire) or
+                dcc_clki_re.match(wire) or
+                dcs_sig_re.match(wire) or
+                center_clk_re.match(wire))
 
 
 # General inter-tile routing
@@ -57,6 +72,7 @@ def is_cib(wire):
 
 h_wire_regex = re.compile(r'H(\d{2})([EW])(\d{2})(\d{2})')
 v_wire_regex = re.compile(r'V(\d{2})([NS])(\d{2})(\d{2})')
+
 
 def handle_edge_name(chip_size, tile_pos, wire_pos, netname):
     """
@@ -104,14 +120,14 @@ def handle_edge_name(chip_size, tile_pos, wire_pos, netname):
                 if hm.group(2) == "W":
                     return "H06W{}03".format(hm.group(3)), (wire_pos[0], wire_pos[1] - (3 - int(hm.group(4))))
                 elif hm.group(2) == "E":
-                    return "H06W{}03".format(hm.group(3)), (wire_pos[0], wire_pos[1] - (int(hm.group(4)) - 3))
+                    return "H06E{}03".format(hm.group(3)), (wire_pos[0], wire_pos[1] - (int(hm.group(4)) - 3))
             if tile_pos[1] >= (chip_size[1] - 5):
                 # x+2, H06W0304 --> x+3, H06W0303
                 # x+2, H06E0302 --> x+3, H06E0303
                 if hm.group(2) == "W":
                     return "H06W{}03".format(hm.group(3)), (wire_pos[0], wire_pos[1] + (int(hm.group(4)) - 3))
                 elif hm.group(2) == "E":
-                    return "H06W{}03".format(hm.group(3)), (wire_pos[0], wire_pos[1] + (3 - int(hm.group(4))))
+                    return "H06E{}03".format(hm.group(3)), (wire_pos[0], wire_pos[1] + (3 - int(hm.group(4))))
         else:
             assert False
     if vm:


### PR DESCRIPTION
At the moment this PR contains fuzzers for:
 - TAP_DRIVE and TAP_DRIVE_CIB row clock control tiles
 - CIB tiles (interconnect to top and bottom IO)
 - SPINE tiles for the 45k tiles only (some 25k and 85k SPINE tiles missing)

