### PR TITLE
misc: Fix ecp5-versa{,5g} ispclock.tap -irlen parameter

### DIFF
--- a/misc/openocd/ecp5-versa.cfg
+++ b/misc/openocd/ecp5-versa.cfg
@@ -13,6 +13,6 @@ reset_config none
 adapter_khz 5000
 
 # ispCLOCK device (should be bypassed by jumpers as it causes problems)
-#jtag newtap ispclock tap -irlen 2 -expected-id 0x00191043
+#jtag newtap ispclock tap -irlen 8 -expected-id 0x00191043
 # ECP5 device - LFE5UM-45F
 jtag newtap ecp5 tap -irlen 8 -expected-id 0x01112043

--- a/misc/openocd/ecp5-versa5g.cfg
+++ b/misc/openocd/ecp5-versa5g.cfg
@@ -13,6 +13,6 @@ reset_config none
 adapter_khz 5000
 
 # ispCLOCK device (should be bypassed by jumpers as it causes problems)
-#jtag newtap ispclock tap -irlen 2 -expected-id 0x00191043
+#jtag newtap ispclock tap -irlen 8 -expected-id 0x00191043
 # ECP5 device - LFE5UM5G-45F
 jtag newtap ecp5 tap -irlen 8 -expected-id 0x81112043


### PR DESCRIPTION
Should be 8 according to datasheet.

This is still not uncommented because `svf -tap ecp5.tap` does not
seem to work for me.