### PR TITLE
Refactor out duplicate "tile name to location mapping".

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -9,6 +9,9 @@
                 "bits_per_frame": 592,
                 "pad_bits_after_frame": 0,
                 "pad_bits_before_frame": 0,
+                "max_row" : 50,
+                "max_col" : 72,
+                "col_bias" : 0,
                 "fuzz": 1
             },
             "LFE5U-45F": {
@@ -18,6 +21,9 @@
                 "bits_per_frame": 846,
                 "pad_bits_after_frame": 0,
                 "pad_bits_before_frame": 2,
+                "max_row" : 71,
+                "max_col" : 90,
+                "col_bias" : 0,
                 "fuzz": 1
             },
             "LFE5U-85F": {
@@ -27,6 +33,9 @@
                 "bits_per_frame": 1136,
                 "pad_bits_after_frame": 0,
                 "pad_bits_before_frame": 0,
+                "max_row" : 95,
+                "max_col" : 126,
+                "col_bias" : 0,
                 "fuzz": 1
             },
             "LFE5UM-25F": {
@@ -36,6 +45,9 @@
                 "bits_per_frame": 592,
                 "pad_bits_after_frame": 0,
                 "pad_bits_before_frame": 0,
+                "max_row" : 50,
+                "max_col" : 72,
+                "col_bias" : 0,
                 "fuzz": 1
             },
             "LFE5UM-45F": {
@@ -45,6 +57,9 @@
                 "bits_per_frame": 846,
                 "pad_bits_after_frame": 0,
                 "pad_bits_before_frame": 2,
+                "max_row" : 71,
+                "max_col" : 90,
+                "col_bias" : 0,
                 "fuzz": 1
             },
             "LFE5UM-85F": {
@@ -54,6 +69,9 @@
                 "bits_per_frame": 1136,
                 "pad_bits_after_frame": 0,
                 "pad_bits_before_frame": 0,
+                "max_row" : 95,
+                "max_col" : 126,
+                "col_bias" : 0,
                 "fuzz": 1
             },
             "LFE5UM5G-25F": {
@@ -63,6 +81,9 @@
                 "bits_per_frame": 592,
                 "pad_bits_after_frame": 0,
                 "pad_bits_before_frame": 0,
+                "max_row" : 50,
+                "max_col" : 72,
+                "col_bias" : 0,
                 "fuzz": 1
             },
             "LFE5UM5G-45F": {
@@ -72,6 +93,9 @@
                 "bits_per_frame": 846,
                 "pad_bits_after_frame": 0,
                 "pad_bits_before_frame": 2,
+                "max_row" : 71,
+                "max_col" : 90,
+                "col_bias" : 0,
                 "fuzz": 1
             },
             "LFE5UM5G-85F": {
@@ -81,6 +105,9 @@
                 "bits_per_frame": 1136,
                 "pad_bits_after_frame": 0,
                 "pad_bits_before_frame": 0,
+                "max_row" : 95,
+                "max_col" : 126,
+                "col_bias" : 0,
                 "fuzz": 1
             }
         }

--- a/libtrellis/include/Chip.hpp
+++ b/libtrellis/include/Chip.hpp
@@ -22,6 +22,11 @@ struct ChipInfo
     int bits_per_frame;
     int pad_bits_before_frame;
     int pad_bits_after_frame;
+    // 0-based.
+    int max_row;
+    int max_col;
+    // Trellis uses 0-based indexing, but some devices don't.
+    int col_bias;
 };
 
 // Information about the global networks in a chip

--- a/libtrellis/include/Tile.hpp
+++ b/libtrellis/include/Tile.hpp
@@ -2,11 +2,13 @@
 #define LIBTRELLIS_TILE_HPP
 
 #include <string>
+#include <iostream>
 #include <cstdint>
 #include <utility>
 #include <regex>
 #include <cassert>
 #include "CRAM.hpp"
+#include "Util.hpp"
 
 namespace Trellis {
 
@@ -42,8 +44,16 @@ struct TileInfo {
 
     inline pair<int, int> get_row_col() const {
         smatch m;
-        assert(regex_search(name, m, tile_row_col_re));
-        return make_pair(stoi(m.str(1)), stoi(m.str(2)));
+        bool match;
+
+        match = regex_search(name, m, tile_row_col_re);
+        if(match) {
+            auto row_col = make_pair(stoi(m.str(1)), stoi(m.str(2)));
+            assert(row_col <= make_pair(int(max_row), int(max_col)));
+            return row_col;
+        } else {
+            throw runtime_error(fmt("Could not extract position from " << name));
+        }
     };
 
     // Get the Lattice name

--- a/libtrellis/include/Tile.hpp
+++ b/libtrellis/include/Tile.hpp
@@ -28,6 +28,9 @@ struct SiteInfo {
 struct TileInfo {
     string family;
     string device;
+    size_t max_col;
+    size_t max_row;
+    int col_bias;
 
     string name;
     string type;

--- a/libtrellis/include/Tile.hpp
+++ b/libtrellis/include/Tile.hpp
@@ -8,12 +8,9 @@
 #include <regex>
 #include <cassert>
 #include "CRAM.hpp"
-#include "Util.hpp"
 
 namespace Trellis {
-
-// Regex to extract row/column from a tile name
-static const regex tile_row_col_re(R"(R(\d+)C(\d+))");
+pair<int, int> get_row_col_pair_from_chipsize(string name, pair<int, int> chip_size, int bias);
 
 // Basic information about a site
 struct SiteInfo {
@@ -43,17 +40,10 @@ struct TileInfo {
     vector<SiteInfo> sites;
 
     inline pair<int, int> get_row_col() const {
-        smatch m;
-        bool match;
-
-        match = regex_search(name, m, tile_row_col_re);
-        if(match) {
-            auto row_col = make_pair(stoi(m.str(1)), stoi(m.str(2)));
-            assert(row_col <= make_pair(int(max_row), int(max_col)));
-            return row_col;
-        } else {
-            throw runtime_error(fmt("Could not extract position from " << name));
-        }
+        auto chip_size = make_pair(int(max_row), int(max_col));
+        auto row_col = get_row_col_pair_from_chipsize(name, chip_size, col_bias);
+        assert(row_col <= chip_size);
+        return row_col;
     };
 
     // Get the Lattice name

--- a/libtrellis/src/Chip.cpp
+++ b/libtrellis/src/Chip.cpp
@@ -88,18 +88,12 @@ vector<shared_ptr<Tile>> Chip::get_all_tiles()
 
 int Chip::get_max_row() const
 {
-    return max_element(tiles.begin(), tiles.end(),
-                       [](const decltype(tiles)::value_type &a, const decltype(tiles)::value_type &b) {
-                           return a.second->info.get_row_col().first < b.second->info.get_row_col().first;
-                       })->second->info.get_row_col().first;
+    return info.max_row;
 }
 
 int Chip::get_max_col() const
 {
-    return max_element(tiles.begin(), tiles.end(),
-                       [](const decltype(tiles)::value_type &a, const decltype(tiles)::value_type &b) {
-                           return a.second->info.get_row_col().second < b.second->info.get_row_col().second;
-                       })->second->info.get_row_col().second;
+    return info.max_col;
 }
 
 ChipDelta operator-(const Chip &a, const Chip &b)

--- a/libtrellis/src/Database.cpp
+++ b/libtrellis/src/Database.cpp
@@ -77,6 +77,9 @@ ChipInfo get_chip_info(const DeviceLocator &part) {
     ci.pad_bits_after_frame = dev.get<int>("pad_bits_after_frame");
     ci.pad_bits_before_frame = dev.get<int>("pad_bits_before_frame");
     ci.idcode = parse_uint32(dev.get<string>("idcode"));
+    ci.max_row = dev.get<int>("max_row");
+    ci.max_col = dev.get<int>("max_col");
+    ci.col_bias = dev.get<int>("col_bias");
     return ci;
 }
 
@@ -120,6 +123,7 @@ vector<TileInfo> get_device_tilegrid(const DeviceLocator &part) {
     assert(db_root != "");
     string tilegrid_path = db_root + "/" + part.family + "/" + part.device + "/tilegrid.json";
     {
+        ChipInfo info = get_chip_info(part);
         lock_guard <mutex> lock(tilegrid_cache_mutex);
         if (tilegrid_cache.find(part.device) == tilegrid_cache.end()) {
             pt::ptree tg_parsed;
@@ -132,6 +136,10 @@ vector<TileInfo> get_device_tilegrid(const DeviceLocator &part) {
             TileInfo ti;
             ti.family = part.family;
             ti.device = part.device;
+            ti.max_col = info.max_col;
+            ti.max_row = info.max_row;
+            ti.col_bias = info.col_bias;
+
             ti.name = tile.first;
             ti.num_frames = size_t(tile.second.get<int>("cols"));
             ti.bits_per_frame = size_t(tile.second.get<int>("rows"));

--- a/libtrellis/src/PyTrellis.cpp
+++ b/libtrellis/src/PyTrellis.cpp
@@ -81,7 +81,10 @@ BOOST_PYTHON_MODULE (pytrellis)
             .def_readonly("num_frames", &ChipInfo::num_frames)
             .def_readonly("bits_per_frame", &ChipInfo::bits_per_frame)
             .def_readonly("pad_bits_before_frame", &ChipInfo::pad_bits_before_frame)
-            .def_readonly("pad_bits_after_frame", &ChipInfo::pad_bits_after_frame);
+            .def_readonly("pad_bits_after_frame", &ChipInfo::pad_bits_after_frame)
+            .def_readonly("max_row", &ChipInfo::max_row)
+            .def_readonly("max_col", &ChipInfo::max_col)
+            .def_readonly("col_bias", &ChipInfo::col_bias);
 
     class_<map<string, shared_ptr<Tile>>>("TileMap")
             .def(map_indexing_suite<map<string, shared_ptr<Tile>>, true>());
@@ -173,6 +176,8 @@ BOOST_PYTHON_MODULE (pytrellis)
             .def(vector_indexing_suite<CRAMDelta>());
 
     // From Tile.cpp
+    def("get_row_col_pair_from_chipsize", get_row_col_pair_from_chipsize);
+
     class_<vector<SiteInfo>>("SiteInfoVector")
             .def(vector_indexing_suite<vector<SiteInfo>>());
 

--- a/libtrellis/src/Tile.cpp
+++ b/libtrellis/src/Tile.cpp
@@ -3,8 +3,25 @@
 #include "Database.hpp"
 #include "BitDatabase.hpp"
 #include "TileConfig.hpp"
+#include "Util.hpp"
 
 namespace Trellis {
+// Regex to extract row/column from a tile name
+static const regex tile_rxcx_re(R"(R(\d+)C(\d+))");
+
+// Universal function to get a zero-indexed row/column pair.
+pair<int, int> get_row_col_pair_from_chipsize(string name, pair<int, int> chip_size, int bias) {
+    smatch m;
+    bool match;
+
+    match = regex_search(name, m, tile_rxcx_re);
+    if(match) {
+        return make_pair(stoi(m.str(1)), stoi(m.str(2)));
+    } else {
+        throw runtime_error(fmt("Could not extract position from " << name));
+    }
+}
+
 Tile::Tile(Trellis::TileInfo info, Trellis::Chip &parent) : info(info), cram(parent.cram.make_view(info.frame_offset,
                                                                                                    info.bit_offset,
                                                                                                    info.num_frames,

--- a/tools/connectivity.py
+++ b/tools/connectivity.py
@@ -24,52 +24,52 @@ def main():
     # Returns (source, configurable, loc)
     def get_fanin(net):
         drivers = []
-        npos = tiles.pos_from_name(net)
+        npos = tiles.pos_from_name(net, chip_size, 0)
         for tile in c.get_all_tiles():
             tinf = tile.info
             tname = tinf.name
-            pos = tiles.pos_from_name(tname)
+            pos = tiles.pos_from_name(tname, chip_size, 0)
             if abs(pos[0] - npos[0]) >= 10 or abs(pos[1] - npos[1]) >= 10:
                 continue
             if net.startswith("G_"):
                 tnet = net
             else:
-                tnet = nets.normalise_name(chip_size, tname, net)
+                tnet = nets.normalise_name(chip_size, tname, net, 0)
             tdb = pytrellis.get_tile_bitdata(pytrellis.TileLocator(c.info.family, c.info.name, tinf.type))
             try:
                 mux = tdb.get_mux_data_for_sink(tnet)
                 for src in mux.get_sources():
-                    drivers.append((nets.canonicalise_name(chip_size, tname, src), True, tname))
+                    drivers.append((nets.canonicalise_name(chip_size, tname, src, 0), True, tname))
             except IndexError:
                 pass
             for fc in tdb.get_fixed_conns():
                 if fc.sink == tnet:
-                    drivers.append((nets.canonicalise_name(chip_size, tname, fc.source), False, tname))
+                    drivers.append((nets.canonicalise_name(chip_size, tname, fc.source, 0), False, tname))
         return drivers
 
     # Get fan-out of a net
     # Returns (dest, configurable, loc)
     def get_fanout(net):
         drivers = []
-        npos = tiles.pos_from_name(net)
+        npos = tiles.pos_from_name(net, chip_size, 0)
         for tile in c.get_all_tiles():
             tinf = tile.info
             tname = tinf.name
-            pos = tiles.pos_from_name(tname)
+            pos = tiles.pos_from_name(tname, chip_size, 0)
             if abs(pos[0] - npos[0]) >= 12 or abs(pos[1] - npos[1]) >= 12:
                 continue
             if net.startswith("G_"):
                 tnet = net
             else:
-                tnet = nets.normalise_name(chip_size, tname, net)
+                tnet = nets.normalise_name(chip_size, tname, net, 0)
             tdb = pytrellis.get_tile_bitdata(pytrellis.TileLocator(c.info.family, c.info.name, tinf.type))
             for sink in tdb.get_sinks():
                 mux = tdb.get_mux_data_for_sink(sink)
                 if tnet in mux.arcs:
-                    drivers.append((nets.canonicalise_name(chip_size, tname, sink), True, tname))
+                    drivers.append((nets.canonicalise_name(chip_size, tname, sink, 0), True, tname))
             for fc in tdb.get_fixed_conns():
                 if fc.source == tnet:
-                    drivers.append((nets.canonicalise_name(chip_size, tname, fc.sink), False, tname))
+                    drivers.append((nets.canonicalise_name(chip_size, tname, fc.sink, 0), False, tname))
         return drivers
 
 
@@ -105,7 +105,7 @@ def main():
     def completer(str, idx):
         if not tile_net_re.match(str):
             return None
-        loc = tiles.pos_from_name(str)
+        loc = tiles.pos_from_name(str, chip_size, 0)
         nets = get_nets_at(loc)
         for n in nets:
             if n.startswith(str):

--- a/tools/demobuilder/design.py
+++ b/tools/demobuilder/design.py
@@ -32,7 +32,8 @@ class Design:
         for tile in all_tiles:
             tinf = tile.info
             tname = tinf.name
-            pos = tiles.pos_from_name(tname)
+            chip_size = (self.chip.get_max_row(), self.chip.get_max_col())
+            pos = tiles.pos_from_name(tname, chip_size, 0)
             if tinf.type == "PLC2":
                 for loc in ("A", "B", "C", "D"):
                     bel = "R{}C{}{}".format(pos[0], pos[1], loc)
@@ -60,7 +61,8 @@ class Design:
         bel = self.bel_for_cell(name, "SLICE")
         beltype, belloc = self.bels[bel]
         tile, loc = belloc
-        pos = tiles.pos_from_name(tile)
+        chip_size = (self.chip.get_max_row(), self.chip.get_max_col())
+        pos = tiles.pos_from_name(tile, chip_size, 0)
         net_prefix = "R{}C{}".format(pos[0], pos[1])
         slice_index = "ABCD".index(loc)
         lc0 = 2 * slice_index

--- a/tools/demobuilder/route.py
+++ b/tools/demobuilder/route.py
@@ -22,8 +22,9 @@ class Autorouter:
             return self.dh_arc_cache[wire]
         else:
             drivers = []
+            chip_size = (self.chip.get_max_row(), self.chip.get_max_col())
             try:
-                npos = tiles.pos_from_name(wire)
+                npos = tiles.pos_from_name(wire, chip_size, 0)
             except AssertionError:
                 return []
             wname = wire.split("_", 1)[1]
@@ -41,20 +42,20 @@ class Autorouter:
                     tname = tinf.name
                     if tname.startswith("TAP"):
                         continue
-                    pos = tiles.pos_from_name(tname)
+                    pos = tiles.pos_from_name(tname, chip_size, 0)
 
                     if abs(pos[0] - npos[0]) not in (vspan, 0) or abs(pos[1] - npos[1]) not in (hspan, 0):
                         continue
                     if wire.startswith("G_"):
                         twire = wire
                     else:
-                        twire = nets.normalise_name(self.chip_size, tname, wire)
+                        twire = nets.normalise_name(self.chip_size, tname, wire, 0)
 
                     tdb = pytrellis.get_tile_bitdata(
                         pytrellis.TileLocator(self.chip.info.family, self.chip.info.name, tinf.type))
                     downhill = tdb.get_downhill_wires(twire)
                     for sink in downhill:
-                        nn = nets.canonicalise_name(self.chip_size, tname, sink.first)
+                        nn = nets.canonicalise_name(self.chip_size, tname, sink.first, 0)
                         if nn is not None:
                             drivers.append((nn, sink.second, tname))
             self.dh_arc_cache[wire] = drivers
@@ -72,8 +73,8 @@ class Autorouter:
         else:
             self.net_to_wire[net] = {dest_wire}
         if configurable and not exists:
-            src_wirename = nets.normalise_name(self.chip_size, tile, uphill_wire)
-            sink_wirename = nets.normalise_name(self.chip_size, tile, dest_wire)
+            src_wirename = nets.normalise_name(self.chip_size, tile, uphill_wire, 0)
+            sink_wirename = nets.normalise_name(self.chip_size, tile, dest_wire, 0)
             config[tile].add_arc(sink_wirename, src_wirename)
 
     # Bind a net to a wire (used for port connections)
@@ -88,9 +89,10 @@ class Autorouter:
     # Route a net to a wire
     def route_net_to_wire(self, net, wire, config):
         print("     Routing net '{}' to wire/pin '{}'...".format(net, wire))
-        dest_pos = tiles.pos_from_name(wire)
+        chip_size = (self.chip.get_max_row(), self.chip.get_max_col())
+        dest_pos = tiles.pos_from_name(wire, chip_size, 0)
         def get_score(x_wire):
-            pos = tiles.pos_from_name(x_wire)
+            pos = tiles.pos_from_name(x_wire, chip_size, 0)
             score = abs(pos[0] - dest_pos[0]) + abs(pos[1] - dest_pos[1])
             x_wname = x_wire.split("_", 1)[1]
             if x_wname[1:3].isdigit() and score > 3:

--- a/util/common/nets.py
+++ b/util/common/nets.py
@@ -196,7 +196,7 @@ def handle_edge_name(chip_size, tile_pos, wire_pos, netname):
     return netname, wire_pos
 
 
-def normalise_name(chip_size, tile, wire):
+def normalise_name(chip_size, tile, wire, bias):
     """
     Wire name normalisation for tile wires and fuzzing
     All net names that we have access too are canonical, global names
@@ -224,13 +224,14 @@ def normalise_name(chip_size, tile, wire):
     chip_size: chip size as tuple (max_row, max_col)
     tile: name of the relevant tile
     wire: full Lattice name of the wire
+    bias: Use 1-based column indexing
 
     Returns the normalised netname
     """
     upos = wire.index("_")
     prefix = wire[:upos]
-    prefix_pos = tiles.pos_from_name(prefix)
-    tile_pos = tiles.pos_from_name(tile)
+    prefix_pos = tiles.pos_from_name(prefix, chip_size, bias)
+    tile_pos = tiles.pos_from_name(tile, chip_size, bias)
     netname = wire[upos+1:]
     if tile.startswith("TAP") and netname.startswith("H"):
         if prefix_pos[1] < tile_pos[1]:
@@ -269,7 +270,7 @@ def normalise_name(chip_size, tile, wire):
 rel_netname_re = re.compile(r'^([NS]\d+)?([EW]\d+)?_.*')
 
 
-def canonicalise_name(chip_size, tile, wire):
+def canonicalise_name(chip_size, tile, wire, bias):
     """
     Convert a normalised name in a given tile back to a canonical global name
     :param chip_size: chip size as tuple (max_row, max_col)
@@ -280,7 +281,7 @@ def canonicalise_name(chip_size, tile, wire):
     if wire.startswith("G_"):
         return wire
     m = rel_netname_re.match(wire)
-    tile_pos = tiles.pos_from_name(tile)
+    tile_pos = tiles.pos_from_name(tile, chip_size, bias)
     wire_pos = tile_pos
     if m:
         assert len(m.groups()) >= 1
@@ -314,17 +315,17 @@ def main():
     assert is_cib("R47C58_H06W0003")
     assert is_cib("R47C61_CLK0")
 
-    assert normalise_name((95, 126), "R48C26", "R48C26_B1") == "B1"
-    assert normalise_name((95, 126), "R48C26", "R48C26_HPBX0600") == "G_HPBX0600"
-    assert normalise_name((95, 126), "R48C26", "R48C25_H02E0001") == "W1_H02E0001"
-    assert normalise_name((95, 126), "R48C1", "R48C1_H02E0002") == "W1_H02E0001"
-    assert normalise_name((95, 126), "R82C90", "R79C90_V06S0003") == "N3_V06S0003"
-    assert normalise_name((95, 126), "R5C95", "R3C95_V06S0004") == "N3_V06S0003"
-    assert normalise_name((95, 126), "R1C95", "R1C95_V06S0006") == "N3_V06S0003"
-    assert normalise_name((95, 126), "R3C95", "R2C95_V06S0005") == "N3_V06S0003"
-    assert normalise_name((95, 126), "R82C95", "R85C95_V06N0303") == "S3_V06N0303"
-    assert normalise_name((95, 126), "R90C95", "R92C95_V06N0304") == "S3_V06N0303"
-    assert normalise_name((95, 126), "R93C95", "R94C95_V06N0305") == "S3_V06N0303"
+    assert normalise_name((95, 126), "R48C26", "R48C26_B1", 0) == "B1"
+    assert normalise_name((95, 126), "R48C26", "R48C26_HPBX0600", 0) == "G_HPBX0600"
+    assert normalise_name((95, 126), "R48C26", "R48C25_H02E0001", 0) == "W1_H02E0001"
+    assert normalise_name((95, 126), "R48C1", "R48C1_H02E0002", 0) == "W1_H02E0001"
+    assert normalise_name((95, 126), "R82C90", "R79C90_V06S0003", 0) == "N3_V06S0003"
+    assert normalise_name((95, 126), "R5C95", "R3C95_V06S0004", 0) == "N3_V06S0003"
+    assert normalise_name((95, 126), "R1C95", "R1C95_V06S0006", 0) == "N3_V06S0003"
+    assert normalise_name((95, 126), "R3C95", "R2C95_V06S0005", 0) == "N3_V06S0003"
+    assert normalise_name((95, 126), "R82C95", "R85C95_V06N0303", 0) == "S3_V06N0303"
+    assert normalise_name((95, 126), "R90C95", "R92C95_V06N0304", 0) == "S3_V06N0303"
+    assert normalise_name((95, 126), "R93C95", "R94C95_V06N0305", 0) == "S3_V06N0303"
 
 
 if __name__ == "__main__":

--- a/util/common/tiles.py
+++ b/util/common/tiles.py
@@ -1,15 +1,17 @@
 import re
+import pytrellis
 
-pos_re = re.compile(r'R(\d+)C(\d+)')
 
-
-def pos_from_name(tile):
+def pos_from_name(tile, chip_size, bias):
     """
     Extract the tile position as a (row, column) tuple from its name
     """
-    s = pos_re.search(tile)
-    assert s
-    return int(s.group(1)), int(s.group(2))
+    size = pytrellis.IntPair()
+    size.first = chip_size[0]
+    size.second = chip_size[1]
+
+    pos = pytrellis.get_row_col_pair_from_chipsize(tile, size, bias)
+    return int(pos.first), int(pos.second)
 
 
 def type_from_fullname(tile):

--- a/util/fuzz/interconnect.py
+++ b/util/fuzz/interconnect.py
@@ -27,7 +27,8 @@ def fuzz_interconnect(config,
                       enable_span1_fix=False,
                       func_cib=False,
                       fc_prefix="",
-                      nonlocal_prefix=""):
+                      nonlocal_prefix="",
+                      bias=0):
     """
     The fully-automatic interconnect fuzzer function. This performs the fuzzing and updates the database with the
     results. It is expected that PyTrellis has already been initialised with the database prior to this function being
@@ -48,6 +49,8 @@ def fuzz_interconnect(config,
     :param func_cib: if True, we are fuzzing a special function to CIB interconnect, enable optimisations for this
     :param fc_prefix: add a prefix to non-global fixed connections for device-specific fuzzers
     :param nonlocal_prefix: add a prefix to non-global and non-neighbour wires for device-specific fuzzers
+    :param bias: Apply offset correction for n-based column numbering, n > 0. Used used by Lattice
+    on certain families.
     """
     netdata = isptcl.get_wires_at_position(config.ncd_prf, location)
     netnames = [x[0] for x in netdata]
@@ -67,7 +70,7 @@ def fuzz_interconnect(config,
     if func_cib and not netname_filter_union:
         netnames = list(filter(lambda x: netname_predicate(x, netnames), netnames))
     fuzz_interconnect_with_netnames(config, netnames, netname_predicate, arc_predicate, fc_predicate, func_cib,
-                                    netname_filter_union, False, fc_prefix, nonlocal_prefix)
+                                    netname_filter_union, False, fc_prefix, nonlocal_prefix, bias)
 
 
 def fuzz_interconnect_with_netnames(
@@ -80,7 +83,8 @@ def fuzz_interconnect_with_netnames(
         netname_filter_union=False,
         full_mux_style=False,
         fc_prefix="",
-        nonlocal_prefix=""):
+        nonlocal_prefix="",
+        bias=0):
     """
     Fuzz interconnect given a list of netnames to analyse. Arcs associated these netnames will be found using the Tcl
     API and bits identified as described above.
@@ -96,6 +100,8 @@ def fuzz_interconnect_with_netnames(
     nets much pass the predicate.
     :param full_mux_style: if True, is a full mux, and all 0s is considered a valid config bit possibility
     :param fc_prefix: add a prefix to non-global fixed connections for device-specific fuzzers
+    :param bias: Apply offset correction for n-based column numbering, n > 0. Used used by Lattice
+    on certain families.
     """
     net_arcs = isptcl.get_arcs_on_wires(config.ncd_prf, netnames, not bidir)
     baseline_bitf = config.build_design(config.ncl, {}, "base_")
@@ -105,7 +111,7 @@ def fuzz_interconnect_with_netnames(
     max_col = baseline_chip.get_max_col()
 
     def normalise_arc_in_tile(tile, arc):
-        return tuple(nets.normalise_name((max_row, max_col), tile, x) for x in arc)
+        return tuple(nets.normalise_name((max_row, max_col), tile, x, bias) for x in arc)
 
     def add_nonlocal_prefix(wire):
         if wire.startswith("G_"):


### PR DESCRIPTION
Within Project Trellis, there were no less than 3 separate functions for obtaining a location of a tile from its name. This PR refactors Project Trellis, particularly the Python utility functions, so that all code uses a single function to map a Tile name to a location (`Trellis::get_row_col_pair_from_chipsize`, also exported to `pytrellis`).