### PR TITLE
libtrellis: Allow hex in IDCODE override in ecppack

### DIFF
--- a/libtrellis/tools/ecppack.cpp
+++ b/libtrellis/tools/ecppack.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
     options.add_options()("verbose,v", "verbose output");
     options.add_options()("db", po::value<std::string>(), "Trellis database folder location");
     options.add_options()("usercode", po::value<uint32_t>(), "USERCODE to set in bitstream");
-    options.add_options()("idcode", po::value<uint32_t>(), "IDCODE to override in bitstream");
+    options.add_options()("idcode", po::value<std::string>(), "IDCODE to override in bitstream");
     options.add_options()("freq", po::value<std::string>(), "config frequency in MHz");
     options.add_options()("svf", po::value<std::string>(), "output SVF file");
     options.add_options()("svf-rowsize", po::value<int>(), "SVF row size in bits (default 8000)");
@@ -94,8 +94,16 @@ help:
     Chip c = cc.to_chip();
     if (vm.count("usercode"))
         c.usercode = vm["usercode"].as<uint32_t>();
-    if (vm.count("idcode"))
-        c.info.idcode = vm["idcode"].as<uint32_t>();
+
+    if (vm.count("idcode")) {
+        string idcode_str = vm["idcode"].as<string>();
+        uint32_t idcode = uint32_t(strtoul(idcode_str.c_str(), nullptr, 0));
+        if (idcode == 0) {
+            cerr << "Invalid idcode: " << idcode_str << endl;
+            return 1;
+        }
+        c.info.idcode = idcode;
+    }
 
     map<string, string> bitopts;
 


### PR DESCRIPTION
This brings the IDCODE commandline in line with other tools, such as openocd config TAP IDs etc.
