### PR TITLE
Add a more descriptive error for std::out_of_range in map::at 

### DIFF
--- a/libtrellis/src/BitDatabase.cpp
+++ b/libtrellis/src/BitDatabase.cpp
@@ -267,8 +267,19 @@ boost::optional<string> EnumSettingBits::get_value(const CRAMView &tile, boost::
 void EnumSettingBits::set_value(Trellis::CRAMView &tile, const string &value) const
 {
     if (value != "_NONE_") {
-        auto grp = options.at(value);
-        grp.set_group(tile);
+        if(options.find(value) != options.end()) {
+            auto grp = options.at(value);
+            grp.set_group(tile);
+	}
+	else {
+	    cerr << "EnumSettingBits::set_value: cannot set " << value  << endl;
+	    cerr << "In Options: " << endl;
+	    for(auto it = options.begin(); it != options.end(); ++it){
+	      cerr << it->first << " -> " << it->second << endl;
+	    }
+
+	    exit(1);
+	}
     }
 }
 


### PR DESCRIPTION
When an unsupported I/O voltage or mode is set on a pin, it triggers a std::out_of_range exception in EnumSettingBits::set_value, which doesn't give a nice error message. This prints out the failing key and  range of options stored in the map, making debugging a little easier.  