### PR TITLE
WIP: Add IOLogic simulation models

### DIFF
--- a/sim/.gitignore
+++ b/sim/.gitignore
@@ -1,0 +1,5 @@
+*~
+lattice/
+*.exe
+*.vcd 
+a.out

--- a/sim/BB.v
+++ b/sim/BB.v
@@ -1,0 +1,16 @@
+module BB(/*AUTOARG*/
+    // Outputs
+    O,
+    // Inouts
+    B,
+    // Inputs
+    I, T
+    );
+    input I, T;
+    output O;
+    inout  B;
+
+    assign B = (T == 1'b1) ? 1'bZ : I;
+
+    assign O = B;
+endmodule // BB

--- a/sim/BB.v
+++ b/sim/BB.v
@@ -1,3 +1,4 @@
+`timescale 1ns/1ps
 module BB(/*AUTOARG*/
     // Outputs
     O,

--- a/sim/IB.v
+++ b/sim/IB.v
@@ -1,0 +1,3 @@
+module IB(input I, output O);
+    assign O = I;
+endmodule // IB

--- a/sim/IDDRX1F.v
+++ b/sim/IDDRX1F.v
@@ -1,0 +1,46 @@
+`timescale 1ns/1ps
+module IDDRX1F(/*AUTOARG*/
+    // Outputs
+    Q0, Q1,
+    // Inputs
+    D, SCLK, RST
+    );
+    input D, SCLK, RST;
+    output reg Q0, Q1;
+    initial
+      {Q0, Q1} = 2'b0;
+
+    reg [1:0] pipe_1;
+
+    parameter GSR = "ENABLED";
+    wire   gsr, pur;
+    gsr_pur_assign gsr_inst(gsr, pur);
+    reg   sr;
+    always @(*)
+      if(GSR == "ENABLED")
+	sr = !(gsr && pur);
+      else
+	sr = !pur;
+    wire  rst_internal = RST || sr;
+
+    reg   last_clock;
+    always @(SCLK)
+      last_clock <= SCLK;
+
+    
+    always @(SCLK or rst_internal) begin
+	if(rst_internal == 1'b1) begin
+	    pipe_1 <= 2'b0;
+	end
+	else if(SCLK === 1'b1 && last_clock === 1'b0) begin
+	    pipe_1[0] <= D;
+	    {Q1, Q0} <= pipe_1;
+	end
+	
+	else if(SCLK === 1'b0 && last_clock === 1'b1)
+	  pipe_1[1] <= D;
+    end // always @ (SCLK or rst_internal)
+    
+      
+      
+endmodule // IDDRX1F

--- a/sim/ILVDS.v
+++ b/sim/ILVDS.v
@@ -1,0 +1,5 @@
+module ILVDS(input A, AN, output Z);
+    assign Z = A; //yeah, they really did this, no checking of AN
+endmodule // ILVDS
+
+    

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -1,4 +1,4 @@
-FILES:= ODDRX1F.v BB.v IDDRX1F.v
+FILES:= ODDRX1F.v BB.v IDDRX1F.v ODDRX2F.v
 TESTBENCHES:= $(patsubst %.v, tests/test_%.v, $(FILES))
 VCDS:= $(patsubst %.v, %.vcd, $(FILES))
 VFLAGS:=-Dmixed_hdl -Wtimescale -Wall 

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -1,7 +1,7 @@
-FILES:= ODDRX1F.v BB.v
+FILES:= ODDRX1F.v BB.v IDDRX1F.v
 TESTBENCHES:= $(patsubst %.v, tests/test_%.v, $(FILES))
 VCDS:= $(patsubst %.v, %.vcd, $(FILES))
-VFLAGS:=-Dmixed_hdl -Wtimescale
+VFLAGS:=-Dmixed_hdl -Wtimescale -Wall 
 
 all: $(VCDS)
 

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -1,4 +1,4 @@
-FILES:= ODDRX1F.v
+FILES:= ODDRX1F.v BB.v
 TESTBENCHES:= $(patsubst %.v, tests/test_%.v, $(FILES))
 VCDS:= $(patsubst %.v, %.vcd, $(FILES))
 VFLAGS:=-Dmixed_hdl -Wtimescale

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -1,0 +1,12 @@
+FILES:= ODDRX1F.v
+TESTBENCHES:= $(patsubst %.v, tests/test_%.v, $(FILES))
+VCDS:= $(patsubst %.v, %.vcd, $(FILES))
+VFLAGS:=-Dmixed_hdl -Wtimescale
+
+all: $(VCDS)
+
+%.exe: tests/test_%.v %.v lattice/%_l.v gsr_pur_assign.v
+	iverilog $(VFLAGS) -o $@ $^ 
+%.vcd: %.exe
+	vvp $<
+

--- a/sim/OB.v
+++ b/sim/OB.v
@@ -1,0 +1,3 @@
+module OB(input I, output O);
+    assign O = I;
+endmodule // OB

--- a/sim/OBZ.v
+++ b/sim/OBZ.v
@@ -1,0 +1,3 @@
+module OBZ(input I, T, output O);
+    assign O = (T == 1) ? 1'bZ : I;
+endmodule // OBZ

--- a/sim/ODDRX1F.v
+++ b/sim/ODDRX1F.v
@@ -1,0 +1,47 @@
+`timescale 1ns/1ps
+module ODDRX1F(/*AUTOARG*/
+    // Outputs
+    Q,
+    // Inputs
+    D0, D1, SCLK, RST
+    );
+
+    input D0, D1, SCLK, RST;
+    output Q;
+
+    parameter GSR = "ENABLED";
+    wire   gsr, pur;
+    gsr_pur_assign gsr_inst(gsr, pur);
+    reg   sr;
+    always @(*)
+      if(GSR == "ENABLED")
+	sr = !(gsr && pur);
+      else
+	sr = !pur;
+
+    wire   rst_internal;
+    assign rst_internal = RST | sr;
+      
+
+
+    assign Q = SCLK ? pipe_3[1] : pipe_3[0];
+
+    reg [1:0] pipe_1, pipe_2, pipe_3;
+    always @(posedge SCLK or rst_internal) begin
+	if(rst_internal) begin
+	    /*AUTORESET*/
+	    // Beginning of autoreset for uninitialized flops
+	    pipe_1 <= 2'h0;
+	    pipe_2 <= 2'h0;
+	    pipe_3 <= 2'h0;
+	    // End of automatics
+	end
+	
+	else if(SCLK == 1) begin
+	    pipe_1 <= {D0, D1};
+	    pipe_2 <= pipe_1;
+	    pipe_3 <= pipe_2;
+	end
+    end
+
+endmodule // ODDRX1F

--- a/sim/ODDRX2F.v
+++ b/sim/ODDRX2F.v
@@ -1,0 +1,61 @@
+`timescale 1ns/1ps
+module ODDRX2F(/*AUTOARG*/
+    // Outputs
+    Q,
+    // Inputs
+    D0, D1, D2, D3, RST, ECLK, SCLK
+    );
+    input D0, D1, D2, D3;
+    input RST;
+    input ECLK, SCLK;
+    output reg Q;
+
+    parameter GSR = "ENABLED";
+    wire   gsr, pur;
+    gsr_pur_assign gsr_inst(gsr, pur);
+    reg   sr;
+    always @(*)
+      if(GSR == "ENABLED")
+	sr = !(gsr && pur);
+      else
+	sr = !pur;
+
+    wire   rst_internal;
+    assign rst_internal = RST | sr;
+
+    reg [3:0] pipe_1;
+    reg [3:0] pipe_2;
+    reg [3:0] pipe_3;
+    reg [1:0] out_next;
+
+    always @(posedge SCLK or posedge rst_internal)
+	if(rst_internal == 1'b1) begin
+	    pipe_1 <= 4'h0;
+	    pipe_2 <= 4'h0;
+	    pipe_3 <= 4'h0;
+	end
+	else begin
+	  pipe_1 <= {D3, D2, D1, D0};
+	    pipe_2 <= pipe_1;
+	    pipe_3 <= pipe_2;
+	end
+    
+
+    always @(SCLK or posedge rst_internal)
+	if(rst_internal == 1'b1) 
+	    out_next <= 4'h0;
+	else if(SCLK === 1)
+	  out_next <= pipe_2[1:0];
+	else 
+	  out_next <= pipe_3[3:2];
+    always @(ECLK or posedge rst_internal)
+      if(rst_internal == 1'b1)
+	Q <= 1'b0;
+      else if(ECLK === 1)
+	Q <= out_next[0];
+      else if(ECLK === 0)
+	Q <= out_next[1];
+    
+
+      
+endmodule // ODDRX2F

--- a/sim/OLVDS.v
+++ b/sim/OLVDS.v
@@ -1,0 +1,4 @@
+module OLVDS(input A, output Z, ZN);
+    assign Z = A;
+    assign ZN = ~A;
+endmodule // OLVDS

--- a/sim/gsr_pur_assign.v
+++ b/sim/gsr_pur_assign.v
@@ -1,0 +1,16 @@
+module gsr_pur_assign(/*AUTOARG*/
+    // Outputs
+    GSR, PUR
+    );
+    output reg GSR, PUR;
+    initial begin
+	GSR = 0;
+	PUR = 0;
+	#10 GSR = 1;
+	PUR = 1;
+    end
+endmodule // gsr_pur_assign
+
+    
+    
+    

--- a/sim/gsr_pur_assign.v
+++ b/sim/gsr_pur_assign.v
@@ -1,3 +1,4 @@
+`timescale 1ns/1ps
 module gsr_pur_assign(/*AUTOARG*/
     // Outputs
     GSR, PUR

--- a/sim/tests/test_BB.v
+++ b/sim/tests/test_BB.v
@@ -1,3 +1,4 @@
+`timescale 1ns/1ps
 module test_BB;
     wire B_sim, B_lat;
     wire O_sim, O_lat;

--- a/sim/tests/test_BB.v
+++ b/sim/tests/test_BB.v
@@ -1,0 +1,32 @@
+module test_BB;
+    wire B_sim, B_lat;
+    wire O_sim, O_lat;
+    reg  I, T;
+
+    reg  b_q, b_tri;
+    assign B_sim = b_tri ? 1'bz : b_q;
+    assign B_lat = b_tri ? 1'bz : b_q;
+    BB sim( .I(I),
+	    .T(T),
+	    .B(B_sim),
+	    .O(O_sim));
+    BB_l lat( .I(I),
+	    .T(T),
+	    .B(B_lat),
+	    .O(O_lat));
+    initial begin
+	$dumpfile("BB.vcd");
+	$dumpvars;
+
+	b_tri = 1;
+	b_q = 0;
+	I = 0;
+	T = 0;
+	#10 I = 1;
+	#10 T = 1;
+	b_tri = 0;
+	#10 b_q = 1;
+	#10 I = 0;
+	#20 $finish;
+    end // UNMATCHED !!
+endmodule // test_BB

--- a/sim/tests/test_IDDRX1F.v
+++ b/sim/tests/test_IDDRX1F.v
@@ -1,0 +1,61 @@
+`timescale 1ns/1ps
+module test_IDDRX1F;
+    reg D, SCLK, RST;
+    wire Q0_sim, Q1_sim;
+    wire Q0_lat, Q1_lat;
+    wire diff = Q0_sim != Q0_lat || Q1_sim != Q1_lat;
+
+    IDDRX1F sim(
+		.D(D),
+		.SCLK(SCLK),
+		.RST(RST),
+		.Q0(Q0_sim),
+		.Q1(Q1_sim));
+    IDDRX1F_l lat(
+		.D(D),
+		.SCLK(SCLK),
+		.RST(RST),
+		.Q0(Q0_lat),
+		.Q1(Q1_lat));
+
+    
+    initial begin
+	$dumpfile("IDDRX1F.vcd");
+	$dumpvars;
+	SCLK = 0;
+	D = 0;
+	RST = 0;
+	@(posedge SCLK)
+	  D = 1;
+	@(negedge SCLK)
+	  D = 0;
+	@(posedge SCLK)
+	  D = 1;
+	@(negedge SCLK)
+	  D = 1;
+	@(posedge SCLK)
+	  D = 0;
+	@(negedge SCLK)
+	  D = 1;
+	@(posedge SCLK)
+	  D = 0;
+	@(negedge SCLK)
+	  D = 0;
+	@(posedge SCLK)
+	  RST = 1;
+	D = 1;
+	@(posedge SCLK)
+	  RST = 0;
+
+	@(posedge SCLK);
+	@(posedge SCLK);
+
+	$finish;
+    end
+    always #5 SCLK = ~SCLK;
+
+    
+    
+	  
+endmodule // test_IDDRX1F
+

--- a/sim/tests/test_ODDRX1F.v
+++ b/sim/tests/test_ODDRX1F.v
@@ -1,0 +1,54 @@
+`timescale 1ns/1ps
+module test_ODDRX1F;
+    reg D0, D1, SCLK, RST;
+    wire sim_Q, lat_Q;
+
+    wire diff = sim_Q !== lat_Q;
+
+    ODDRX1F sim(/*AUTOINST*/
+		// Outputs
+		.Q			(sim_Q),
+		// Inputs
+		.D0			(D0),
+		.D1			(D1),
+		.SCLK			(SCLK),
+		.RST			(RST));
+    ODDRX1F_l lattice(/*AUTOINST*/
+		      // Outputs
+		      .Q			(lat_Q),
+		      // Inputs
+		      .D0			(D0),
+		      .D1			(D1),
+		      .SCLK			(SCLK),
+		      .RST			(RST));
+    initial begin
+	$dumpfile("ODDRX1F.vcd");
+	$dumpvars;
+	#200 $finish;
+    end
+
+    initial begin
+	SCLK = 1;
+	RST = 0;
+	D0 = 0;
+	D1 = 0;
+	#10 RST = 0;
+	#10 RST = 0;
+	#10 D0 = 1;
+	#10 D1 = 1;
+	#10 D0 = 0;
+	#20 RST = 1;
+	#10 RST = 0;
+	#20 RST = 1;
+	#10 RST = 0;
+    end
+    
+
+    always #5 SCLK <= ~SCLK; 
+      
+
+endmodule // test_ODDRX1F
+
+// Local Variables:
+// verilog-library-flags:("-y ../ -y../lattice")
+// End:

--- a/sim/tests/test_ODDRX2F.v
+++ b/sim/tests/test_ODDRX2F.v
@@ -1,0 +1,61 @@
+`timescale 1ns/1ps
+module test_ODDRX2F;
+    wire D0, D1, D2, D3;
+    reg [3:0] D;
+    assign {D3, D2, D1, D0} = D;
+    reg RST, ECLK, SCLK;
+    wire Q_sim, Q_lat;
+    ODDRX2F sim(
+		.D0(D0),
+		.D1(D1),
+		.D2(D2),
+		.D3(D3),
+		.RST(RST),
+		.ECLK(ECLK),
+		.SCLK(SCLK),
+		.Q(Q_sim));
+    ODDRX2F_l lat(
+		.D0(D0),
+		.D1(D1),
+		.D2(D2),
+		.D3(D3),
+		.RST(RST),
+		.ECLK(ECLK),
+		.SCLK(SCLK),
+		.Q(Q_lat));
+    wire diff = Q_lat != Q_sim;
+    always begin
+	#5 ECLK = 0;
+	SCLK = 0;
+	#5 ECLK = 1;
+	#5 ECLK = 0;
+	SCLK = 1;
+	#5 ECLK = 1;
+    end
+    
+    integer i;
+    initial begin
+	$dumpfile("ODDRX2F.vcd");
+	$dumpvars;
+	D = 4'b0;
+	RST = 1'b1;
+	#20 RST = 1'b0;
+	for(i=0; i<16; i++)
+	  @(posedge SCLK) D = i;
+	RST = 1'b1;
+	for(i=0; i<5; i++)
+	  @(posedge SCLK) D = i;
+	RST = 1'b0;
+	for(i=5; i<12; i++)
+	  @(posedge SCLK) D = i;
+	RST = 1'b1;
+	@(posedge SCLK) RST = 1'b0;
+	for(i=0; i<16; i++)
+	  @(posedge SCLK) D = i;
+	
+
+	#80 $finish;
+    end
+    
+
+endmodule // test_ODDRX2F


### PR DESCRIPTION
The testbenches in the tests/ directory reference modules such as ODDRX1F_l, these are the lattice simulation files (not included) renamed to have _l as a suffix.

- [ ] Add a shell script to auto-rename the lattice files
- [ ] Add README
- [ ] Add IDDRX2F
- [ ] Add IDDRX2DQA and ODDRX2DQA
- [ ] Add ODDRX2DQSB 
- [ ] Add TSHX2DQA and TSHX2DQSA

I don't really think it's necessary to add the input and output buffers with pull-ups/downs, but I can add them if need be.