### PR TITLE
Remove redundant --45k option from picorv32_ulx3s Makefile

### DIFF
--- a/examples/picorv32_ulx3s/Makefile
+++ b/examples/picorv32_ulx3s/Makefile
@@ -14,7 +14,7 @@ attosoc.json: io_wrapper.v attosoc.v picorv32.v firmware.hex
 	yosys -p "synth_ecp5 -json $@" io_wrapper.v attosoc.v picorv32.v
 
 attosoc_out.config: attosoc.json
-	nextpnr-ecp5 --45k --package CABGA381 --json $< --textcfg $@ --45k --no-tmdriv
+	nextpnr-ecp5 --45k --package CABGA381 --json $< --textcfg $@ --no-tmdriv
 
 attosoc.bit: attosoc_out.config
 	ecppack $< $@


### PR DESCRIPTION
Currently this fails with:
  nextpnr-ecp5 --45k --package CABGA381 --json attosoc.json --textcfg attosoc_out.config --45k --no-tmdriv
  option '--45k' cannot be specified more than once

Remove redundant option.

Signed-off-by: Michael Neuling <mikey@neuling.org>