### PR TITLE
IOLOGIC improvements

### DIFF
--- a/fuzzers/ECP5/067-ioreg/fuzzer.py
+++ b/fuzzers/ECP5/067-ioreg/fuzzer.py
@@ -93,7 +93,7 @@ def main():
     pytrellis.load_database("../../../database")
 
     def per_job(job):
-        def get_substs(regtype="", regen="OFF", regset="RESET", srmode="ASYNC", regmode="FF", ceimux="1", ceomux="1", datamux="PADDO"):
+        def get_substs(regtype="", regen="OFF", regset="RESET", srmode="ASYNC", regmode="FF", cemux="CE", ceimux="1", ceomux="1", datamux="PADDO", trimux="PADDT"):
             clkimux = "CLK"
             clkomux = "CLK"
             if regen == "ON":
@@ -109,7 +109,9 @@ def main():
                 s = "S"
             else:
                 s = ""
-            return dict(loc=loc, reg=reg, s=s, pin=pin, srmode=srmode, clkimux=clkimux, clkomux=clkomux, ceimux=ceimux, ceomux=ceomux, datamux=datamux)
+            if cemux == "INV":
+                cemux = "CE:::CE=#INV"
+            return dict(loc=loc, reg=reg, s=s, pin=pin, srmode=srmode, clkimux=clkimux, clkomux=clkomux, cemux=cemux, ceimux=ceimux, ceomux=ceomux, datamux=datamux, trimux=trimux)
 
         cfg = job["cfg"]
         loc = job["site"]
@@ -143,10 +145,14 @@ def main():
                                      lambda x: get_substs(srmode=x), empty_bitfile, False)
         nonrouting.fuzz_enum_setting(cfg, "IOLOGIC{}.CEIMUX".format(iol), ["CEMUX", "1"],
                                      lambda x: get_substs(ceimux=x), empty_bitfile, False)
+        nonrouting.fuzz_enum_setting(cfg, "IOLOGIC{}.CEMUX".format(iol), ["CE", "INV"],
+                                     lambda x: get_substs(cemux=x), empty_bitfile, False)
         nonrouting.fuzz_enum_setting(cfg, "IOLOGIC{}.CEOMUX".format(iol), ["CEMUX", "1"],
                                      lambda x: get_substs(ceomux=x), empty_bitfile, False)
         nonrouting.fuzz_enum_setting(cfg, "PIO{}.DATAMUX_OREG".format(iol), ["PADDO", "IOLDO"],
                                      lambda x: get_substs(datamux=x), empty_bitfile, False)
+        nonrouting.fuzz_enum_setting(cfg, "PIO{}.TRIMUX_TSREG".format(iol), ["PADDT", "IOLTO"],
+                                     lambda x: get_substs(trimux=x), empty_bitfile, False)
     fuzzloops.parallel_foreach(jobs, per_job)
 
 

--- a/fuzzers/ECP5/067-ioreg/iologic.ncl
+++ b/fuzzers/ECP5/067-ioreg/iologic.ncl
@@ -16,6 +16,7 @@ design top
          cellmodel-name ${s}IOLOGIC;
          program "GSR:ENABLED "
                  "MODE:IREG_OREG "
+                 "CEMUX:${cemux} "
                  "CEIMUX:${ceimux} "
                  "SRMODE:${srmode} "
                  "CEOMUX:${ceomux} "
@@ -34,7 +35,8 @@ design top
       logical
       {
          cellmodel-name PIO;
-         program "DATAMUX:${datamux}";
+         program "DATAMUX:${datamux} "
+                 "TRIMUX:${trimux}";
          primitive IOBUF Q_pad;
          primitive PAD Q;
       }

--- a/libtrellis/src/Bels.cpp
+++ b/libtrellis/src/Bels.cpp
@@ -551,6 +551,22 @@ void add_ioclk_bel(RoutingGraph &graph, const std::string &name, int x, int y, i
         bel.name = graph.ident("ECLKBUF" + std::to_string(i));
         graph.add_bel_input(bel, graph.ident("ECLKI"), x, y, graph.ident(fmt("JECLK" << i)));
         graph.add_bel_output(bel, graph.ident("ECLKO"), 0, 0, graph.ident(fmt("G_BANK" << bank << "ECLK" << i)));
+    } else if (name == "ECLKBRIDGECS") {
+        postfix = "ECLKBRIDGECS" + std::to_string(i);
+        bel.name = graph.ident(postfix);
+        bel.z = 14;
+        add_input("CLK0");
+        add_input("CLK1");
+        add_input("SEL");
+        add_output("ECSOUT", true);
+    } else if (name == "BRGECLKSYNC") {
+        postfix = "BRGECLKSYNC" + std::to_string(i);
+        bel.name = graph.ident(postfix);
+        bel.type = graph.ident("ECLKSYNCB");
+        bel.z = 15;
+        add_input("ECLKI", false);
+        add_input("STOP");
+        add_output("ECLKO");
     } else if (name == "DLLDELD") {
         postfix = "DLLDEL";
         bel.name = graph.ident(postfix);

--- a/libtrellis/src/Bels.cpp
+++ b/libtrellis/src/Bels.cpp
@@ -559,7 +559,7 @@ void add_ioclk_bel(RoutingGraph &graph, const std::string &name, int x, int y, i
         add_input("CLK0");
         add_input("CLK1");
         add_input("SEL");
-        add_output("ECSOUT", true);
+        add_output("ECSOUT", false);
     } else if (name == "BRGECLKSYNC") {
         postfix = "BRGECLKSYNC" + std::to_string(i);
         bel.name = graph.ident(postfix);

--- a/libtrellis/src/Bels.cpp
+++ b/libtrellis/src/Bels.cpp
@@ -426,6 +426,7 @@ void add_iologic(RoutingGraph &graph, int x, int y, int z, bool s) {
             add_input("TXDATA4");
             add_input("TXDATA5");
             add_input("TXDATA6");
+            add_input("SLIP");
             add_output("RXDATA4");
             add_output("RXDATA5");
             add_output("RXDATA6");

--- a/libtrellis/src/Chip.cpp
+++ b/libtrellis/src/Chip.cpp
@@ -213,6 +213,8 @@ shared_ptr<RoutingGraph> Chip::get_routing_graph()
             Bels::add_ioclk_bel(*rg, "DLLDELD", x-2, y, 0);
             Bels::add_ioclk_bel(*rg, "DLLDELD", x-2, y+1, 0);
             Bels::add_ioclk_bel(*rg, "DLLDELD", x-2, y+2, 0);
+            Bels::add_ioclk_bel(*rg, "ECLKBRIDGECS", x-2, y, 1);
+            Bels::add_ioclk_bel(*rg, "BRGECLKSYNC", x-2, y, 1);
         }
         if (tile->info.type == "ECLK_R") {
             Bels::add_ioclk_bel(*rg, "CLKDIVF", x+2, y, 0);
@@ -229,6 +231,8 @@ shared_ptr<RoutingGraph> Chip::get_routing_graph()
             Bels::add_ioclk_bel(*rg, "DLLDELD", x+2, y, 0);
             Bels::add_ioclk_bel(*rg, "DLLDELD", x+2, y+1, 0);
             Bels::add_ioclk_bel(*rg, "DLLDELD", x+2, y+2, 0);
+            Bels::add_ioclk_bel(*rg, "ECLKBRIDGECS", x+2, y, 0);
+            Bels::add_ioclk_bel(*rg, "BRGECLKSYNC", x+2, y, 0);
         }
         if (tile->info.type == "DDRDLL_UL")
             Bels::add_ioclk_bel(*rg, "DDRDLL", x-2, y-10, 0);

--- a/minitests/iologic/iddr7.v
+++ b/minitests/iologic/iddr7.v
@@ -1,0 +1,9 @@
+module oddr7(input D, input ALIGNWD, ECLK, RST, output [3:0] Q);
+wire SCLK;
+
+CLKDIVF #(.DIV("3.5")) cdiv_i (.CLKI(ECLK), .RST(RST), .ALIGNWD(1'b0), .CDIVX(SCLK));
+
+IDDR71B oddr_i(.Q0(Q[0]), .Q1(Q[1]), .Q2(Q[2]), .Q3(Q[3]),
+               .ECLK(ECLK), .SCLK(SCLK), .ALIGNWD(ALIGNWD), .RST(RST),
+               .D(D));
+endmodule

--- a/minitests/iologic/oreg.v
+++ b/minitests/iologic/oreg.v
@@ -1,0 +1,5 @@
+module top(input clk, ce, lsr, d, output q);
+	OFS1P3IX oreg_i (.D(d), .SCLK(clk), .SP(ce), .CD(lsr), 
+.Q(q));
+endmodule
+

--- a/minitests/iologic/toreg.v
+++ b/minitests/iologic/toreg.v
@@ -1,0 +1,8 @@
+module top(input clk, ce, lsr, d, t, output p);
+	wire tr, q;
+	OFS1P3IX oreg_i (.D(d), .SCLK(clk), .SP(ce), .CD(lsr), .Q(q));
+	OFS1P3IX treg_i (.D(t), .SCLK(clk), .SP(ce), .CD(lsr), .Q(tr));
+
+	OBZ ob_i(.I(q), .T(tr), .O(p));
+endmodule
+


### PR DESCRIPTION
 - Add ECLKBRIDGECS and associated BRGECLKSYNC bels to libtrellis
 - Add the SLIP pin to the IOLOGIC Bel, needed for 7:1 input mode
 - Add missing config bits related to IO registers