### PR TITLE
examples: allows to override TRELLIS when libtrellis is not installed in /usr

### DIFF
--- a/examples/ecp5_evn/Makefile
+++ b/examples/ecp5_evn/Makefile
@@ -1,5 +1,5 @@
 PROJ=blinky
-TRELLIS=/usr/share/trellis
+TRELLIS?=/usr/share/trellis
 
 all: ${PROJ}.bit
 

--- a/examples/picorv32_versa5g/Makefile
+++ b/examples/picorv32_versa5g/Makefile
@@ -1,4 +1,4 @@
-TRELLIS=/usr/share/trellis
+TRELLIS?=/usr/share/trellis
 
 firmware.elf: sections.lds firmware.s
 	riscv32-unknown-elf-gcc -march=rv32i -Wl,-Bstatic,-T,sections.lds,--strip-debug -ffreestanding -nostdlib -o firmware.elf firmware.s

--- a/examples/soc_ecp5_evn/Makefile
+++ b/examples/soc_ecp5_evn/Makefile
@@ -1,4 +1,4 @@
-TRELLIS=/usr/share/trellis
+TRELLIS?=/usr/share/trellis
 
 firmware.elf: sections.lds start.s firmware.c
 	riscv32-unknown-elf-gcc -march=rv32i -Wl,-Bstatic,-T,sections.lds,--strip-debug -ffreestanding -nostdlib -o firmware.elf start.s firmware.c

--- a/examples/soc_versa5g/Makefile
+++ b/examples/soc_versa5g/Makefile
@@ -1,4 +1,4 @@
-TRELLIS=/usr/share/trellis
+TRELLIS?=/usr/share/trellis
 
 firmware.elf: sections.lds start.s firmware.c
 	riscv32-unknown-elf-gcc -march=rv32i -Wl,-Bstatic,-T,sections.lds,--strip-debug -ffreestanding -nostdlib -o firmware.elf start.s firmware.c

--- a/examples/versa5g/Makefile
+++ b/examples/versa5g/Makefile
@@ -1,6 +1,6 @@
 PROJ=demo
 CONSTR=versa.lpf
-TRELLIS=/usr/share/trellis
+TRELLIS?=/usr/share/trellis
 
 all: ${PROJ}.bit
 


### PR DESCRIPTION
By default, make prog uses $(TRELLIS) to provides the openocd config file path.
This variable is hardcoded to /usr/share/trellis, so if libtrellis is installed in other location (/usr/local is the cmake default path) openocd fails with:
embedded:startup.tcl:60: Error: Can't find /usr/share/trellis/misc/openocd/ecp5-evn.cfg

By replacing = by ?=, it's now possible to use:
TRELLIS=/usr/local/share/trellis make prog