### PR TITLE
Refactor util tools

### DIFF
--- a/libtrellis/.gitignore
+++ b/libtrellis/.gitignore
@@ -19,8 +19,22 @@ install_manifest.txt
 ecpbram
 ecppack
 ecpunpack
+ecpmulti
 ecppll
 libtrellis.dylib
 *~
 ecpmulti
 generated/
+
+# Windows
+ecpbram.exe
+ecppack.exe
+ecpunpack.exe
+ecpmulti.exe
+ecppll.exe
+pytrellis.pyd
+
+# Ninja
+.ninja_*
+build.ninja
+rules.ninja

--- a/libtrellis/include/Tile.hpp
+++ b/libtrellis/include/Tile.hpp
@@ -1,7 +1,6 @@
 #ifndef LIBTRELLIS_TILE_HPP
 #define LIBTRELLIS_TILE_HPP
 
-#include <iostream>
 #include <string>
 #include <iostream>
 #include <cstdint>

--- a/libtrellis/include/Tile.hpp
+++ b/libtrellis/include/Tile.hpp
@@ -1,6 +1,7 @@
 #ifndef LIBTRELLIS_TILE_HPP
 #define LIBTRELLIS_TILE_HPP
 
+#include <iostream>
 #include <string>
 #include <iostream>
 #include <cstdint>

--- a/libtrellis/src/Tile.cpp
+++ b/libtrellis/src/Tile.cpp
@@ -6,17 +6,50 @@
 #include "Util.hpp"
 
 namespace Trellis {
-// Regex to extract row/column from a tile name
+// Regexes to extract row/column from a tile name.
 static const regex tile_rxcx_re(R"(R(\d+)C(\d+))");
+
+// MachXO2-specific, in order of precedence (otherwise, e.g.
+// CENTER_EBR matches r_regex)
+static const regex tile_center_re(R"(CENTER(\d+))");
+static const regex tile_centerb_re(R"(CENTER_B)");
+static const regex tile_centert_re(R"(CENTER_T)");
+static const regex tile_centerebr_re(R"(CENTER_EBR(\d+))");
+static const regex tile_t_re(R"([A-Za-z0-9_]*T(\d+))");
+static const regex tile_b_re(R"([A-Za-z0-9_]*B(\d+))");
+static const regex tile_l_re(R"([A-Za-z0-9_]*L(\d+))");
+static const regex tile_r_re(R"([A-Za-z0-9_]*R(\d+))");
+
+// Given the zero-indexed max chip_size, return the zero-indexed
+// center. Mainly for MachXO2.
+// TODO: Make const.
+map<pair<int, int>, pair<int, int>> center_map = {
+    {make_pair(12, 21), make_pair(6, 12)}
+};
 
 // Universal function to get a zero-indexed row/column pair.
 pair<int, int> get_row_col_pair_from_chipsize(string name, pair<int, int> chip_size, int bias) {
     smatch m;
-    bool match;
 
-    match = regex_search(name, m, tile_rxcx_re);
-    if(match) {
-        return make_pair(stoi(m.str(1)), stoi(m.str(2)));
+    if(regex_search(name, m, tile_rxcx_re)) {
+        return make_pair(stoi(m.str(1)), stoi(m.str(2)) - bias);
+    } else if(regex_search(name, m, tile_centert_re)) {
+        return make_pair(0, center_map[chip_size].second);
+    } else if(regex_search(name, m, tile_centerb_re)) {
+        return make_pair(chip_size.first, center_map[chip_size].second);
+    } else if(regex_search(name, m, tile_centerebr_re)) {
+        // TODO: This may not apply to devices larger than 1200.
+        return make_pair(center_map[chip_size].first, stoi(m.str(1)) - bias);
+    } else if(regex_search(name, m, tile_center_re)) {
+        return make_pair(stoi(m.str(1)), center_map[chip_size].second);
+    } else if(regex_search(name, m, tile_t_re)) {
+        return make_pair(0, stoi(m.str(1)) - bias);
+    } else if(regex_search(name, m, tile_b_re)) {
+        return make_pair(chip_size.first, stoi(m.str(1)) - bias);
+    } else if(regex_search(name, m, tile_l_re)) {
+        return make_pair(stoi(m.str(1)), 0);
+    } else if(regex_search(name, m, tile_r_re)) {
+        return make_pair(stoi(m.str(1)), chip_size.second);
     } else {
         throw runtime_error(fmt("Could not extract position from " << name));
     }

--- a/libtrellis/src/Tile.cpp
+++ b/libtrellis/src/Tile.cpp
@@ -24,6 +24,7 @@ static const regex tile_r_re(R"([A-Za-z0-9_]*R(\d+))");
 // center. Mainly for MachXO2.
 // TODO: Make const.
 map<pair<int, int>, pair<int, int>> center_map = {
+    // 1200HC
     {make_pair(12, 21), make_pair(6, 12)}
 };
 

--- a/tools/demobuilder/design.py
+++ b/tools/demobuilder/design.py
@@ -6,6 +6,7 @@ import tiles
 class Design:
     def __init__(self, family):
         self.chip = pytrellis.Chip("LFE5U-45F")
+        self.bias = self.chip.info.col_bias
         self.router = route.Autorouter(self.chip)
         self.config = {_.info.name: pytrellis.TileConfig() for _ in self.chip.get_all_tiles()}
         # TODO: load skeleton config
@@ -33,7 +34,7 @@ class Design:
             tinf = tile.info
             tname = tinf.name
             chip_size = (self.chip.get_max_row(), self.chip.get_max_col())
-            pos = tiles.pos_from_name(tname, chip_size, 0)
+            pos = tiles.pos_from_name(tname, chip_size, self.bias)
             if tinf.type == "PLC2":
                 for loc in ("A", "B", "C", "D"):
                     bel = "R{}C{}{}".format(pos[0], pos[1], loc)
@@ -62,7 +63,7 @@ class Design:
         beltype, belloc = self.bels[bel]
         tile, loc = belloc
         chip_size = (self.chip.get_max_row(), self.chip.get_max_col())
-        pos = tiles.pos_from_name(tile, chip_size, 0)
+        pos = tiles.pos_from_name(tile, chip_size, self.bias)
         net_prefix = "R{}C{}".format(pos[0], pos[1])
         slice_index = "ABCD".index(loc)
         lc0 = 2 * slice_index

--- a/tools/extract_tilegrid.py
+++ b/tools/extract_tilegrid.py
@@ -25,6 +25,8 @@ site_re = re.compile(
     r'^\s+([A-Z0-9_]+) \((-?\d+), (-?\d+)\)')
 
 parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('-m', action="store_true",
+                    help="Use MachXO2 family layout")
 parser.add_argument('infile', type=argparse.FileType('r'),
                     help="input file from bstool")
 parser.add_argument('outfile', type=argparse.FileType('w'),
@@ -38,14 +40,24 @@ def main(argv):
         tile_m = tile_re.match(line)
         if tile_m:
             name = tile_m.group(6)
-            current_tile = {
-                "type": tile_m.group(1),
-                "start_bit": int(tile_m.group(4)),
-                "start_frame": int(tile_m.group(5)),
-                "rows": int(tile_m.group(2)),
-                "cols": int(tile_m.group(3)),
-                "sites": []
-            }
+            if args.m:
+                current_tile = {
+                    "type": tile_m.group(1),
+                    "start_bit": int(tile_m.group(5)),
+                    "start_frame": int(tile_m.group(4)),
+                    "rows": int(tile_m.group(3)),
+                    "cols": int(tile_m.group(2)),
+                    "sites": []
+                }
+            else:
+                current_tile = {
+                    "type": tile_m.group(1),
+                    "start_bit": int(tile_m.group(4)),
+                    "start_frame": int(tile_m.group(5)),
+                    "rows": int(tile_m.group(2)),
+                    "cols": int(tile_m.group(3)),
+                    "sites": []
+                }
             identifier = name + ":" + tile_m.group(1)
             assert identifier not in tiles
             tiles[identifier] = current_tile

--- a/tools/get_tilegrid_all.py
+++ b/tools/get_tilegrid_all.py
@@ -21,9 +21,13 @@ def main():
     devices = database.get_devices()
     for family in sorted(devices["families"].keys()):
         for device in sorted(devices["families"][family]["devices"].keys()):
-            diamond.run(device, "work_tilegrid/wire.v")
-            output_file = path.join(database.get_db_subdir(family, device), "tilegrid.json")
-            extract_tilegrid.main(["extract_tilegrid", "work_tilegrid/wire.tmp/output.test", output_file])
+            if devices["families"][family]["devices"][device]["fuzz"]:
+                diamond.run(device, "work_tilegrid/wire.v")
+                output_file = path.join(database.get_db_subdir(family, device), "tilegrid.json")
+                if family in ["MachXO2"]:
+                    extract_tilegrid.main(["extract_tilegrid", "-m", "work_tilegrid/wire.tmp/output.test", output_file])
+                else:
+                    extract_tilegrid.main(["extract_tilegrid", "work_tilegrid/wire.tmp/output.test", output_file])
 
 
 if __name__ == "__main__":

--- a/tools/html_all.py
+++ b/tools/html_all.py
@@ -84,8 +84,6 @@ def main(argv):
     docs_toc = ""
     pytrellis.load_database(database.get_db_root())
     for fam, fam_data in sorted(database.get_devices()["families"].items()):
-        if fam == "MachXO2":
-            continue
         fdir = path.join(args.fld, fam)
         if not path.exists(fdir):
             os.mkdir(fdir)
@@ -112,33 +110,35 @@ def main(argv):
                     dev
                 )
 
-        docs_toc += "</ul>"
-        docs_toc += "<h4>Cell Timing Documentation</h4>"
-        docs_toc += "<ul>"
-        for spgrade in ["6", "7", "8", "8_5G"]:
-            tdir = path.join(fdir, "timing")
-            if not path.exists(tdir):
-                os.mkdir(tdir)
-            docs_toc += '<li><a href="{}">Speed Grade -{}</a></li>'.format(
-                '{}/timing/cell_timing_{}.html'.format(fam, spgrade),
-                spgrade
-            )
-            cell_html.make_cell_timing_html(timing_dbs.cells_db_path(fam, spgrade), fam, spgrade,
-                                            path.join(tdir, 'cell_timing_{}.html'.format(spgrade)))
-        docs_toc += "</ul>"
-        docs_toc += "<h4>Interconnect Timing Documentation</h4>"
-        docs_toc += "<ul>"
-        for spgrade in ["6", "7", "8", "8_5G"]:
-            tdir = path.join(fdir, "timing")
-            if not path.exists(tdir):
-                os.mkdir(tdir)
-            docs_toc += '<li><a href="{}">Speed Grade -{}</a></li>'.format(
-                '{}/timing/interconn_timing_{}.html'.format(fam, spgrade),
-                spgrade
-            )
-            interconnect_html.make_interconn_timing_html(timing_dbs.interconnect_db_path(fam, spgrade), fam, spgrade,
-                                            path.join(tdir, 'interconn_timing_{}.html'.format(spgrade)))
-        docs_toc += "</ul>"
+        # No timing stuff for MachXO2 yet.
+        if fam in ["ECP5"]:
+            docs_toc += "</ul>"
+            docs_toc += "<h4>Cell Timing Documentation</h4>"
+            docs_toc += "<ul>"
+            for spgrade in ["6", "7", "8", "8_5G"]:
+                tdir = path.join(fdir, "timing")
+                if not path.exists(tdir):
+                    os.mkdir(tdir)
+                docs_toc += '<li><a href="{}">Speed Grade -{}</a></li>'.format(
+                    '{}/timing/cell_timing_{}.html'.format(fam, spgrade),
+                    spgrade
+                )
+                cell_html.make_cell_timing_html(timing_dbs.cells_db_path(fam, spgrade), fam, spgrade,
+                                                path.join(tdir, 'cell_timing_{}.html'.format(spgrade)))
+            docs_toc += "</ul>"
+            docs_toc += "<h4>Interconnect Timing Documentation</h4>"
+            docs_toc += "<ul>"
+            for spgrade in ["6", "7", "8", "8_5G"]:
+                tdir = path.join(fdir, "timing")
+                if not path.exists(tdir):
+                    os.mkdir(tdir)
+                docs_toc += '<li><a href="{}">Speed Grade -{}</a></li>'.format(
+                    '{}/timing/interconn_timing_{}.html'.format(fam, spgrade),
+                    spgrade
+                )
+                interconnect_html.make_interconn_timing_html(timing_dbs.interconnect_db_path(fam, spgrade), fam, spgrade,
+                                                path.join(tdir, 'interconn_timing_{}.html'.format(spgrade)))
+            docs_toc += "</ul>"
 
     index_html = Template(trellis_docs_index).substitute(
         datetime=build_dt,

--- a/tools/html_tilegrid.py
+++ b/tools/html_tilegrid.py
@@ -46,6 +46,7 @@ def main(argv):
 
     max_row = device_info["max_row"]
     max_col = device_info["max_col"]
+    bias = device_info["col_bias"]
 
     tiles = []
     for i in range(max_row + 1):
@@ -56,7 +57,7 @@ def main(argv):
 
     for identifier, data in sorted(tilegrid.items()):
         name = identifier.split(":")[0]
-        row, col = tilelib.pos_from_name(name, (max_row, max_col), 0)
+        row, col = tilelib.pos_from_name(name, (max_row, max_col), bias)
         colour = get_colour(data["type"])
         tiles[row][col].append((name, data["type"], colour))
 

--- a/util/common/nets.py
+++ b/util/common/nets.py
@@ -312,6 +312,16 @@ def canonicalise_name(chip_size, tile, wire, bias):
     return "R{}C{}_{}".format(wire_pos[0], wire_pos[1], wire)
 
 
+# Useful functions for constructing nets.
+def char_range(c1, c2):
+    """Generates the characters from `c1` to `c2`, exclusive."""
+    for c in range(ord(c1), ord(c2)):
+        yield chr(c)
+
+def net_product(net_list, range_iter):
+    return [n.format(i) for i in range_iter for n in net_list]
+
+
 def main():
     assert is_global("R2C7_HPBX0100")
     assert is_global("R24C12_VPTX0700")

--- a/util/fuzz/dbfixup.py
+++ b/util/fuzz/dbfixup.py
@@ -3,7 +3,9 @@ import pytrellis
 """
 Database fix utility
 
-Run at the end of fuzzing to "finalise" the database and remove problems that may occur during fuzzing
+Run at the end of fuzzing to "finalise" the database and remove problems that may occur during fuzzing.
+
+The remaining functions can be called in other fuzzers as necessary.
 """
 
 
@@ -25,4 +27,48 @@ def dbfixup(family, device, tiletype):
                 deleteFc = True
         if deleteFc:
             db.remove_fixed_sink(mux)
+    db.save()
+
+
+def remove_enum_bits(family, device, tiletype, lowerright, upperleft=(0, 0)):
+    """
+    Remove bits from enumerations in a given tile that actually belong
+    to routing bits. This can happen when e.g. routing is required for Diamond
+    to set certain bits in the output, as is the case for fuzzing I/O enums
+    in PIC_L0 and PIC_R0.
+
+    Bounds are (0,0)-based. Upperleft is inclusive, lowerright is exclusive.
+    """
+    def in_bounding_box(bit):
+        (x, y) = (bit.frame, bit.bit)
+
+        if upperleft[0] > x or upperleft[1] > y:
+            return False
+
+        if lowerright[0] <= x or lowerright[1] <= y:
+            return False
+
+        return True
+
+    db = pytrellis.get_tile_bitdata(
+        pytrellis.TileLocator(family, device, tiletype))
+
+    for enum in db.get_settings_enums():
+        fixed_enum = pytrellis.EnumSettingBits()
+
+        for option in db.get_data_for_enum(enum).options:
+            key = option.key()
+            fixed_bg = pytrellis.BitGroup()
+
+            for bit in option.data().bits:
+                if in_bounding_box(bit):
+                    fixed_bg.bits.add(bit)
+
+            fixed_enum.options[key] = fixed_bg
+
+        fixed_enum.name = db.get_data_for_enum(enum).name
+        fixed_enum.defval = db.get_data_for_enum(enum).defval
+
+        db.remove_setting_enum(enum)
+        db.add_setting_enum(fixed_enum)
     db.save()

--- a/util/fuzz/interconnect.py
+++ b/util/fuzz/interconnect.py
@@ -28,6 +28,7 @@ def fuzz_interconnect(config,
                       func_cib=False,
                       fc_prefix="",
                       nonlocal_prefix="",
+                      netdir_override=dict(),
                       bias=0):
     """
     The fully-automatic interconnect fuzzer function. This performs the fuzzing and updates the database with the
@@ -48,6 +49,10 @@ def fuzz_interconnect(config,
     :param enable_span1_fix: if True, include span1 wires that are excluded due to a Tcl API bug
     :param func_cib: if True, we are fuzzing a special function to CIB interconnect, enable optimisations for this
     :param fc_prefix: add a prefix to non-global fixed connections for device-specific fuzzers
+    :param netdir_override: Manually specify whether the nets in the dictionary are driven by other nets (`"sink"`,
+    specified as "-->" in ispTcl), or drive other nets (`"driver"`, specified as "<--" in ispTcl). The dictionary is
+    only consulted if ispTcl returns "---" for the direction of a given net. This dictionary overrides
+    func_cib=False for the nets in question.
     :param nonlocal_prefix: add a prefix to non-global and non-neighbour wires for device-specific fuzzers
     :param bias: Apply offset correction for n-based column numbering, n > 0. Used used by Lattice
     on certain families.
@@ -70,7 +75,7 @@ def fuzz_interconnect(config,
     if func_cib and not netname_filter_union:
         netnames = list(filter(lambda x: netname_predicate(x, netnames), netnames))
     fuzz_interconnect_with_netnames(config, netnames, netname_predicate, arc_predicate, fc_predicate, func_cib,
-                                    netname_filter_union, False, fc_prefix, nonlocal_prefix, bias)
+                                    netname_filter_union, False, fc_prefix, nonlocal_prefix, netdir_override, bias)
 
 
 def fuzz_interconnect_with_netnames(
@@ -84,6 +89,7 @@ def fuzz_interconnect_with_netnames(
         full_mux_style=False,
         fc_prefix="",
         nonlocal_prefix="",
+        netdir_override=dict(),
         bias=0):
     """
     Fuzz interconnect given a list of netnames to analyse. Arcs associated these netnames will be found using the Tcl
@@ -100,10 +106,14 @@ def fuzz_interconnect_with_netnames(
     nets much pass the predicate.
     :param full_mux_style: if True, is a full mux, and all 0s is considered a valid config bit possibility
     :param fc_prefix: add a prefix to non-global fixed connections for device-specific fuzzers
+    :param netdir_override: Manually specify whether the nets in the dictionary are driven by other nets (`"sink"`,
+    specified as "-->" in ispTcl), or drive other nets (`"driver"`, specified as "<--" in ispTcl). The dictionary is
+    only consulted if ispTcl returns "---" for the direction of a given net. This dictionary overrides
+    bidir=False for the nets in question.
     :param bias: Apply offset correction for n-based column numbering, n > 0. Used used by Lattice
     on certain families.
     """
-    net_arcs = isptcl.get_arcs_on_wires(config.ncd_prf, netnames, not bidir)
+    net_arcs = isptcl.get_arcs_on_wires(config.ncd_prf, netnames, not bidir, netdir_override)
     baseline_bitf = config.build_design(config.ncl, {}, "base_")
     baseline_chip = pytrellis.Bitstream.read_bit(baseline_bitf).deserialise_chip()
 


### PR DESCRIPTION
This is two commits... commit e078b48 deals with adding column bias and Windows support to Python files under `tools` and `utils`.

Subsequent commit brings in my changes to libtrellis for dealing with MachXO2's "wonderful" tile-naming scheme, column biasing conversion, as well as bitstream generation (the `BitstreamOptions` class).

While nothing should have broken, _I have not tested the bitstream generation changes on ECP5 (and have no boards to test on). Please make sure nothing breaks before committing._