### PR TITLE
github: build archlinux package

### DIFF
--- a/.github/archlinux/PKGBUILD
+++ b/.github/archlinux/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer: Filipe Laíns (FFY00) <lains@archlinux.org>
+
+_prj=trellis
+_pkgname=prj$_prj
+pkgname=$_pkgname-git
+_commit=%COMMIT%
+pkgver=dummy
+pkgrel=1
+pkgdesc='Documentation and definitions for the Lattice ECP5 bit-stream format'
+arch=('x86_64')
+url='https://github.com/SymbiFlow/prjtrellis'
+license=('custom:ISC' 'MIT')
+depends=('boost-libs' "$_pkgname-db")
+makedepends=('git' 'cmake' 'boost' 'python-sphinx' 'python-sphinx_rtd_theme' 'python-recommonmark')
+optdepends=('python: Python support')
+provides=("$_pkgname")
+conflicts=("$_pkgname")
+source=("git+$url.git#commit=$_commit")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $_pkgname
+
+  printf "%s.r%s.%s" \
+        $(git tag | tail -n1) \
+        $(git rev-list --count HEAD) \
+        $(git rev-parse --short HEAD)
+}
+
+build() {
+  mkdir $_pkgname/libtrellis/build
+  cd $_pkgname/libtrellis/build
+
+  cmake .. \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+    -DCMAKE_BUILD_TYPE=Release
+
+  make
+
+#  cd ../../docs
+#
+#  make html
+}
+
+package() {
+  cd $_pkgname
+
+#  install -dm 755 "$pkgdir"/usr/share/doc/$pkgname
+#  cp -r --no-preserve=ownership docs/_build/* "$pkgdir"/usr/share/doc/$pkgname/
+
+  install -Dm 644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+
+  cd libtrellis/build
+
+  make DESTDIR="$pkgdir" install
+
+  # The database is provided in a separate package
+  rmdir "$pkgdir"/usr/share/$_prj/database
+}
+

--- a/.github/workflows/arch-pkg.yml
+++ b/.github/workflows/arch-pkg.yml
@@ -1,0 +1,19 @@
+name: arch-pkg
+on: [push, pull_request]
+
+jobs:
+  arch-pkg:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux
+      options: --privileged
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Arch Linux package
+        uses: FFY00/build-arch-package@master
+        with:
+          PKGBUILD: $GITHUB_WORKSPACE/.github/archlinux/PKGBUILD
+
+


### PR DESCRIPTION
Example run: https://travis-ci.com/github/FFY00/prjtrellis/builds/160309099

When https://github.com/SymbiFlow/sphinxcontrib-markdown-symlinks/issues/8 gets sorted we can start building the documentation in the package.

Before merging this I think it would make sense to consider using Github Actions instead. Github Actions allows us to reuse actions (example: https://github.com/JamesIves/github-pages-deploy-action, see it in action: https://github.com/libratbag/ratbag-emu/blob/master/.github/workflows/docpush.yml). This would allow us to maintain a separate repo with the package building and artifact deployment logic and then only define the build scripts in the different repos. Github Actions is free and unlimited for open-source, and allows us to host our own runners if needed (travis doesn't support this).

cc @mithro