### PR TITLE
Reverse belsUphill and belsDownhill assignments- agreed to be typo.

### DIFF
--- a/libtrellis/src/RoutingGraph.cpp
+++ b/libtrellis/src/RoutingGraph.cpp
@@ -147,7 +147,7 @@ void RoutingGraph::add_bel_input(RoutingBel &bel, ident_t pin, int wire_x, int w
     belId.loc = bel.loc;
     add_wire(wireId);
     bel.pins[pin] = make_pair(wireId, PORT_IN);
-    tiles[wireId.loc].wires[wireId.id].belsUphill.push_back(make_pair(belId, pin));
+    tiles[wireId.loc].wires[wireId.id].belsDownhill.push_back(make_pair(belId, pin));
 }
 
 void RoutingGraph::add_bel_output(RoutingBel &bel, ident_t pin, int wire_x, int wire_y, ident_t wire_name) {
@@ -159,7 +159,7 @@ void RoutingGraph::add_bel_output(RoutingBel &bel, ident_t pin, int wire_x, int 
     belId.loc = bel.loc;
     add_wire(wireId);
     bel.pins[pin] = make_pair(wireId, PORT_OUT);
-    tiles[wireId.loc].wires[wireId.id].belsDownhill.push_back(make_pair(belId, pin));
+    tiles[wireId.loc].wires[wireId.id].belsUphill.push_back(make_pair(belId, pin));
 }
 
 }


### PR DESCRIPTION
Per IRC messages, we both agree `belsUphill` and `belsDownhill` are reversed from intended. Functionally, this PR shouldn't change anything- other than fixing an [assertion](https://github.com/SymbiFlow/prjtrellis/blob/master/libtrellis/src/DedupChipdb.cpp#L107) because `belsUphill` and `belsDownhill` ultimately become part of the [same](https://github.com/SymbiFlow/prjtrellis/blob/master/libtrellis/src/DedupChipdb.cpp#L101-L113) `vector` during deduplication. `nextpnr` therefore never knows that these data structures were reversed!

However, it's best to correct this for documentation purposes :).

Please make sure to test this PR against generated blobs to make sure nothing breaks. As far as I can tell, these are in fact the only lines that need to be changed.